### PR TITLE
Rename project to product-edc

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: |
-          ghcr.io/catenax-ng/catena-x-edc/edc-controlplane-memory
+          ghcr.io/catenax-ng/product-edc/edc-controlplane-memory
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -103,7 +103,7 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: |
-          ghcr.io/catenax-ng/catena-x-edc/edc-controlplane-cosmosdb
+          ghcr.io/catenax-ng/product-edc/edc-controlplane-cosmosdb
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -138,7 +138,7 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: |
-          ghcr.io/catenax-ng/catena-x-edc/edc-controlplane-postgresql
+          ghcr.io/catenax-ng/product-edc/edc-controlplane-postgresql
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -173,7 +173,7 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: |
-          ghcr.io/catenax-ng/catena-x-edc/edc-dataplane
+          ghcr.io/catenax-ng/product-edc/edc-dataplane
         tags: |
           type=ref,event=branch
           type=ref,event=pr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.1] - 2022-03-29
 
-[Unreleased]: https://github.com/catenax-ng/catena-x-edc/compare/0.0.1...HEAD
+[Unreleased]: https://github.com/catenax-ng/product-edc/compare/0.0.1...HEAD
 
-[0.0.1]: https://github.com/catenax-ng/catena-x-edc/compare/ea573b6816bcbdbf2b1a4416652e551517f893d2...0.0.1
+[0.0.1]: https://github.com/catenax-ng/product-edc/compare/ea573b6816bcbdbf2b1a4416652e551517f893d2...0.0.1

--- a/deployment/helm/edc-controlplane/Chart.yaml
+++ b/deployment/helm/edc-controlplane/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: edc-controlplane
 description: EDC Control-Plane
-home: https://github.com/catenax-ng/catena-x-edc/deployment/helm/edc-controlplane
+home: https://github.com/catenax-ng/product-edc/deployment/helm/edc-controlplane
 type: application
 appVersion: "0.0.1"
 version: 0.0.1

--- a/deployment/helm/edc-controlplane/values.yaml
+++ b/deployment/helm/edc-controlplane/values.yaml
@@ -8,11 +8,11 @@ image:
   ##
   ## Which derivate of the edc controlplane to use.
   ## One of:
-  ##   * ghcr.io/catenax-ng/catena-x-edc/edc-controlplane-memory
-  ##   * ghcr.io/catenax-ng/catena-x-edc/edc-controlplane-postgresql
-  ##   * ghcr.io/catenax-ng/catena-x-edc/edc-controlplane-cosmosdb
+  ##   * ghcr.io/catenax-ng/product-edc/edc-controlplane-memory
+  ##   * ghcr.io/catenax-ng/product-edc/edc-controlplane-postgresql
+  ##   * ghcr.io/catenax-ng/product-edc/edc-controlplane-cosmosdb
   ##
-  repository: ghcr.io/catenax-ng/catena-x-edc/edc-controlplane-memory
+  repository: ghcr.io/catenax-ng/product-edc/edc-controlplane-memory
   pullPolicy: IfNotPresent
   ##
   ## Overrides the image tag whose default is the chart appVersion.

--- a/deployment/helm/edc-dataplane/Chart.yaml
+++ b/deployment/helm/edc-dataplane/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: edc-dataplane
 description: EDC Data-Plane
-home: https://github.com/catenax-ng/catena-x-edc/deployment/helm/edc-dataplane
+home: https://github.com/catenax-ng/product-edc/deployment/helm/edc-dataplane
 type: application
 appVersion: "0.0.1"
 version: 0.0.1

--- a/deployment/helm/edc-dataplane/values.yaml
+++ b/deployment/helm/edc-dataplane/values.yaml
@@ -8,7 +8,7 @@ image:
   ##
   ## Which edc-dataplane container image to use.
   ##
-  repository: ghcr.io/catenax-ng/catena-x-edc/edc-dataplane
+  repository: ghcr.io/catenax-ng/product-edc/edc-dataplane
   pullPolicy: IfNotPresent
   ##
   ## Overrides the image tag whose default is the chart appVersion.

--- a/edc-controlplane/pom.xml
+++ b/edc-controlplane/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <groupId>net.catenax.edc</groupId>
-        <artifactId>catena-x-edc-parent</artifactId>
+        <artifactId>product-edc-parent</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>
 

--- a/edc-dataplane/pom.xml
+++ b/edc-dataplane/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <groupId>net.catenax.edc</groupId>
-        <artifactId>catena-x-edc-parent</artifactId>
+        <artifactId>product-edc-parent</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>
     <artifactId>edc-dataplane</artifactId>

--- a/edc-extensions/pom.xml
+++ b/edc-extensions/pom.xml
@@ -17,7 +17,7 @@
 
     <parent>
         <groupId>net.catenax.edc</groupId>
-        <artifactId>catena-x-edc-parent</artifactId>
+        <artifactId>product-edc-parent</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.catenax.edc</groupId>
-    <artifactId>catena-x-edc-parent</artifactId>
+    <artifactId>product-edc-parent</artifactId>
     <version>0.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
@@ -50,7 +50,7 @@
         <repository>
             <id>github-catenax-ng</id>
             <name>Catena-X NG: Github Packages</name>
-            <url>https://maven.pkg.github.com/catenax-ng/catena-x-edc</url>
+            <url>https://maven.pkg.github.com/catenax-ng/product-edc</url>
         </repository>
     </distributionManagement>
 
@@ -76,7 +76,7 @@
         <repository>
             <id>github-catenax-ng</id>
             <name>Catena-X NG: Github Packages</name>
-            <url>https://maven.pkg.github.com/catenax-ng/catena-x-edc</url>
+            <url>https://maven.pkg.github.com/catenax-ng/product-edc</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
As requested by [Sigi](https://github.com/Siegfriedk) the project shall be renamed to `product-edc` to align with the naming convention within the catenax-ng organization leading to better assignability. 

This Pull-Request changes all links / references containing 'catena-x-edc' to 'product-edc' and **shall be merged after (!)** actually [renaming the repository](https://github.com/catenax-ng/catena-x-edc/settings).

<sub> Denis Neuling <denis.neuling@mercedes-benz.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/mercedes-benz/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>