### PR TITLE
Remove all in-memory stores deps which are now default

### DIFF
--- a/edc-controlplane/edc-controlplane-cosmosdb/pom.xml
+++ b/edc-controlplane/edc-controlplane-cosmosdb/pom.xml
@@ -195,12 +195,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <!-- Cosmosdb not yet supported -->
-            <groupId>org.eclipse.dataspaceconnector</groupId>
-            <artifactId>policy-store-memory</artifactId>
-        </dependency>
-
         <!-- Core -->
         <dependency>
             <groupId>org.eclipse.dataspaceconnector</groupId>

--- a/edc-controlplane/edc-controlplane-memory/pom.xml
+++ b/edc-controlplane/edc-controlplane-memory/pom.xml
@@ -153,30 +153,6 @@
             <artifactId>ids-token-validation</artifactId>
         </dependency>
 
-        <!-- Stores -->
-        <dependency>
-            <groupId>org.eclipse.dataspaceconnector</groupId>
-            <artifactId>assetindex-memory</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.dataspaceconnector</groupId>
-            <artifactId>contractdefinition-store-memory</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.dataspaceconnector</groupId>
-            <artifactId>contractnegotiation-store-memory</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.dataspaceconnector</groupId>
-            <artifactId>transfer-process-store-memory</artifactId>
-        </dependency>
-
-        <dependency>
-            <!-- Cosmosdb not yet supported -->
-            <groupId>org.eclipse.dataspaceconnector</groupId>
-            <artifactId>policy-store-memory</artifactId>
-        </dependency>
-
         <!-- Core -->
         <dependency>
             <groupId>org.eclipse.dataspaceconnector</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -188,11 +188,6 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.dataspaceconnector</groupId>
-                <artifactId>assetindex-memory</artifactId>
-                <version>${org.eclipse.dataspaceconnector.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.dataspaceconnector</groupId>
                 <artifactId>auth-spi</artifactId>
                 <version>${org.eclipse.dataspaceconnector.version}</version>
             </dependency>
@@ -303,22 +298,12 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.dataspaceconnector</groupId>
-                <artifactId>contractdefinition-store-memory</artifactId>
-                <version>${org.eclipse.dataspaceconnector.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.dataspaceconnector</groupId>
                 <artifactId>contractnegotiation-api</artifactId>
                 <version>${org.eclipse.dataspaceconnector.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.dataspaceconnector</groupId>
                 <artifactId>contract-negotiation-store-cosmos</artifactId>
-                <version>${org.eclipse.dataspaceconnector.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.dataspaceconnector</groupId>
-                <artifactId>contractnegotiation-store-memory</artifactId>
                 <version>${org.eclipse.dataspaceconnector.version}</version>
             </dependency>
             <dependency>
@@ -573,11 +558,6 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.dataspaceconnector</groupId>
-                <artifactId>in-memory</artifactId>
-                <version>${org.eclipse.dataspaceconnector.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.dataspaceconnector</groupId>
                 <artifactId>jdk-logger-monitor</artifactId>
                 <version>${org.eclipse.dataspaceconnector.version}</version>
             </dependency>
@@ -634,11 +614,6 @@
             <dependency>
                 <groupId>org.eclipse.dataspaceconnector</groupId>
                 <artifactId>policy-spi</artifactId>
-                <version>${org.eclipse.dataspaceconnector.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.dataspaceconnector</groupId>
-                <artifactId>policy-store-memory</artifactId>
                 <version>${org.eclipse.dataspaceconnector.version}</version>
             </dependency>
             <dependency>
@@ -770,11 +745,6 @@
             <dependency>
                 <groupId>org.eclipse.dataspaceconnector</groupId>
                 <artifactId>transfer-process-store-cosmos</artifactId>
-                <version>${org.eclipse.dataspaceconnector.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.dataspaceconnector</groupId>
-                <artifactId>transfer-process-store-memory</artifactId>
                 <version>${org.eclipse.dataspaceconnector.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
The repo was not buildable anymore with the new edc version