### PR TITLE
Remove keystore configurations

### DIFF
--- a/deployment/helm/edc-controlplane/values.yaml
+++ b/deployment/helm/edc-controlplane/values.yaml
@@ -335,8 +335,6 @@ configuration:
     # edc.ion.crawler.did-type=
     # edc.ion.crawler.interval-minutes=
     # edc.ion.crawler.ion.url=
-    # edc.keystore=
-    # edc.keystore.password=
     # edc.metrics.enabled=
     # edc.metrics.executor.enabled=
     # edc.metrics.jersey.enabled=

--- a/deployment/helm/edc-dataplane/values.yaml
+++ b/deployment/helm/edc-dataplane/values.yaml
@@ -285,8 +285,6 @@ configuration:
     # edc.ion.crawler.did-type=
     # edc.ion.crawler.interval-minutes=
     # edc.ion.crawler.ion.url=
-    # edc.keystore=
-    # edc.keystore.password=
     # edc.metrics.enabled=
     # edc.metrics.executor.enabled=
     # edc.metrics.jersey.enabled=


### PR DESCRIPTION
These are not needed, because they are only used in the `vault-fs` extension of the edc.