### PR TITLE
Replace iam-mock by iam-daps at controlplane-memory

### DIFF
--- a/edc-controlplane/edc-controlplane-memory/README.md
+++ b/edc-controlplane/edc-controlplane-memory/README.md
@@ -94,7 +94,7 @@ edc.oauth.client.id=daps-oauth-client-id
 edc.vault.clientid=00000000-1111-2222-3333-444444444444
 edc.vault.tenantid=55555555-6666-7777-8888-999999999999
 edc.vault.name=my-vault-name
-edc.vault.clientsecret=34-chars-secret=34-chars-secret
+edc.vault.clientsecret=34-chars-secret
 
 # Control- / Data- Plane configuration
 edc.transfer.proxy.endpoint=http://dataplane-public-endpoint/public

--- a/edc-controlplane/edc-controlplane-memory/README.md
+++ b/edc-controlplane/edc-controlplane-memory/README.md
@@ -36,6 +36,14 @@ Details regarding each configuration property can be found at the [documentary s
 | edc.api.control.auth.apikey.key                       |           | X-Api-Key | |
 | edc.api.control.auth.apikey.value                     |           | super-strong-api-key | |
 | edc.hostname                                          |           | localhost | |
+| edc.oauth.token.url                                   | X         | https://daps.catena-x.net | |
+| edc.oauth.public.key.alias                            | X         | key-to-daps-certificate-in-keyvault | |
+| edc.oauth.private.key.alias                           | X         | key-to-private-key-in-keyvault | |
+| edc.oauth.client.id                                   | X         | daps-oauth-client-id | |
+| edc.vault.clientid                                    | X         | 00000000-1111-2222-3333-444444444444 | | 
+| edc.vault.tenantid                                    | X         | 55555555-6666-7777-8888-999999999999 | |
+| edc.vault.name                                        | X         | my-vault-name | |
+| edc.vault.clientsecret                                | X         | 34-chars-secret | |
 | edc.transfer.proxy.endpoint                  | X         | | |
 | edc.transfer.proxy.token.signer.privatekey.alias  | X         | | |
 
@@ -76,12 +84,17 @@ edc.api.control.auth.apikey.value=pass
 
 edc.hostname=localhost
 
+# OAuth / DAPS related configuration
+edc.oauth.token.url=https://daps.catena-x.net
+edc.oauth.public.key.alias=key-to-daps-certificate-in-keyvault
+edc.oauth.private.key.alias=key-to-private-key-in-keyvault
+edc.oauth.client.id=daps-oauth-client-id
 
 # Azure vault related configuration
 edc.vault.clientid=00000000-1111-2222-3333-444444444444
 edc.vault.tenantid=55555555-6666-7777-8888-999999999999
 edc.vault.name=my-vault-name
-edc.vault.clientsecret=34-chars-secret
+edc.vault.clientsecret=34-chars-secret=34-chars-secret
 
 # Control- / Data- Plane configuration
 edc.transfer.proxy.endpoint=http://dataplane-public-endpoint/public

--- a/edc-controlplane/edc-controlplane-memory/pom.xml
+++ b/edc-controlplane/edc-controlplane-memory/pom.xml
@@ -186,7 +186,11 @@
         <!-- IAM -->
         <dependency>
             <groupId>org.eclipse.dataspaceconnector</groupId>
-            <artifactId>iam-mock</artifactId>
+            <artifactId>oauth2-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dataspaceconnector</groupId>
+            <artifactId>iam-daps</artifactId>
         </dependency>
 
         <!-- Telemetry -->


### PR DESCRIPTION
Introduces the org.eclipse.dataspaceconnector:iam-daps and org.eclipse.dataspaceconnector:oauth2-core modules to the [controlplane-memory](https://github.com/catenax-ng/product-edc/tree/feature/control-plane-memory-iam-daps/edc-controlplane/edc-controlplane-memory) in replacement of org.eclipse.dataspaceconnector:iam-mock. Closes #110 

<sub>Denis Neuling <denis.neuling@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/daimler-foss/blob/master/LEGAL_IMPRINT.md) </sub> 