### PR TITLE
update control plane link for json date source

### DIFF
--- a/edc-controlplane/README.md
+++ b/edc-controlplane/README.md
@@ -323,7 +323,7 @@ __apiKey=X-Api-Key
 __apiKeyValue=pwd
 __assetId=1
 __assetDescription="Demo Asset"
-__assetDataEndpoint=https://github.com/eclipse-dataspaceconnector
+__assetDataEndpoint="https://jsonplaceholder.typicode.com/todos/3"
 
 __asset="{
         \"asset\": {


### PR DESCRIPTION
there was a request to replace the asset endpoint with one that is able to deliver real json