### PR TITLE
Use semver version range >=0.0.1 for locally present dependencies

### DIFF
--- a/edc-tests/src/main/resources/deployment/helm/all-in-one/Chart.yaml
+++ b/edc-tests/src/main/resources/deployment/helm/all-in-one/Chart.yaml
@@ -33,15 +33,15 @@ dependencies:
 
   # PLATO CONNECTOR
   - name: edc-controlplane
-    version: 0.0.4
+    version: ">=0.0.1"
     repository: "file://../../../../../../../deployment/helm/edc-controlplane"
     alias: plato-edc-controlplane
   - name: edc-dataplane
-    version: 0.0.4
+    version: ">=0.0.1"
     repository: "file://../../../../../../../deployment/helm/edc-dataplane"
     alias: plato-edc-dataplane
   - name: backend-application
-    version: 0.0.1
+    version: ">=0.0.1"
     repository: "file://../backend-application"
     alias: plato-backend-application
   - name: vault
@@ -55,15 +55,15 @@ dependencies:
 
   # SOKRATES CONNECTOR
   - name: edc-controlplane
-    version: 0.0.4
+    version: ">=0.0.1"
     repository: "file://../../../../../../../deployment/helm/edc-controlplane"
     alias: sokrates-edc-controlplane
   - name: edc-dataplane
-    version: 0.0.4
+    version: ">=0.0.1"
     repository: "file://../../../../../../../deployment/helm/edc-dataplane"
     alias: sokrates-edc-dataplane
   - name: backend-application
-    version: 0.0.1
+    version: ">=0.0.1"
     repository: "file://../backend-application"
     alias: sokrates-backend-application
   - name: vault


### PR DESCRIPTION
According to the [helm documentation](https://helm.sh/docs/chart_best_practices/dependencies/#versions) Chart dependency versions must be expressed using semver and can contain comparison and logical operators - so reasonable to utilize them for locally present charts the [all-in-one Chart](https://github.com/catenax-ng/product-edc/tree/feature/edc-tests-helm-aio-dependency-version-range/edc-tests/src/main/resources/deployment/helm/all-in-one/Chart.yaml) is dependent on. 

<sub>Denis Neuling <denis.neuling@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/daimler-foss/blob/master/LEGAL_IMPRINT.md) </sub>