### PR TITLE
Minor changes to the Readme

### DIFF
--- a/edc-extensions/dataplane-selector-configuration/README.md
+++ b/edc-extensions/dataplane-selector-configuration/README.md
@@ -1,4 +1,4 @@
-# Data Plane Selector Configuration Exception
+# Data Plane Selector Configuration Extension
 
 This control-plane extension makes it possible configure one or more Data Plane Instances. During a transfer the control
 plane will look for an instance with matching capabilities to transfer data.

--- a/edc-extensions/dataplane-selector-configuration/README.md
+++ b/edc-extensions/dataplane-selector-configuration/README.md
@@ -9,10 +9,10 @@ Per data plane instance the following settings must be configured. As `<data-pla
 
 | Key                                                     | Description                                       | Mandatory | Example                                                           |
 |:--------------------------------------------------------|:--------------------------------------------------|-----------|-------------------------------------------------------------------|
-| edc.dataplane.selector.<data-plane-id>.url              | URL to connect to the Data Plane Instance.        | X         | http://plato-edc-dataplane:9999/api/dataplane/control             |
-| edc.dataplane.selector.<data-plane-id>.sourcetypes      | Source Types in a comma separated List.           | X         | HttpData                                                          |
-| edc.dataplane.selector.<data-plane-id>.destinationtypes | Destination Types in a comma separated List.      | X         | HttpProxy                                                         |
-| edc.dataplane.selector.<data-plane-id>.properties       | Additional properties of the Data Plane Instance. | (X)       | { "publicApiUrl": "http://plato-edc-dataplane:8185/api/public/" } |
+| edc.dataplane.selector.``<data-plane-id>``.url              | URL to connect to the Data Plane Instance.        | X         | http://plato-edc-dataplane:9999/api/dataplane/control             |
+| edc.dataplane.selector.``<data-plane-id>``.sourcetypes      | Source Types in a comma separated List.           | X         | HttpData                                                          |
+| edc.dataplane.selector.``<data-plane-id>``.destinationtypes | Destination Types in a comma separated List.      | X         | HttpProxy                                                         |
+| edc.dataplane.selector.``<data-plane-id>``.properties       | Additional properties of the Data Plane Instance. | (X)       | { "publicApiUrl": "http://plato-edc-dataplane:8185/api/public" } |
 
 The property `publicApiUrl` is mandatory for Data Plane Instances with destination type `HttpProxy`.
 


### PR DESCRIPTION
Make ``<data-plane-id>`` visible in table.

Remove trailing slash in public url Example -> this causes double slashes occurring in end-to-end flow.