### PR TITLE
feat(controlplane): support additional volumes

### DIFF
--- a/charts/edc-controlplane/templates/deployment.yaml
+++ b/charts/edc-controlplane/templates/deployment.yaml
@@ -101,6 +101,9 @@ spec:
             - name: configuration
               mountPath: /app/logging.properties
               subPath: logging.properties
+            {{- with .Values.volumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: configuration
           configMap:
@@ -112,6 +115,9 @@ spec:
                 path: opentelemetry.properties
               - key: logging.properties
                 path: logging.properties
+        {{- with .Values.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/edc-controlplane/values.yaml
+++ b/charts/edc-controlplane/values.yaml
@@ -90,6 +90,12 @@ startupProbe:
   # -- Number of seconds after the container has started before liveness probes are initiated.
   initialDelaySeconds: 10
 
+# -- Additional volumeMounts to the controlplane main container
+volumeMounts: []
+
+# -- Additional volumes to the controlplane pod
+volumes: []
+
 ## EDC endpoints exposed by the control-plane
 edc:
   endpoints:


### PR DESCRIPTION
Add support to specify additional volumes (and mounts) to the edc-controlplane.