### PR TITLE
feat: provide multitenancy runtime

### DIFF
--- a/edc-extensions/multi-tenancy/README.md
+++ b/edc-extensions/multi-tenancy/README.md
@@ -1,0 +1,29 @@
+# Multi Tenancy
+
+This extension provide support for a multi-tenant EDC.
+
+## TL;DR
+Please take a look at the [related sample](../../samples/sample-multi-tenancy)
+
+## How to use
+The module provides an extension of the `BaseRuntime` class called `MultiTenantRuntime`.
+Setting this as the main class will make the application look for a properties file which path can be specified with
+the `edc.tenants.path` property.
+
+In this file the tenants are defined through settings, e.g.:
+```properties
+edc.tenants.tenant1.edc.fs.config=/config/path
+edc.tenants.tenant2.edc.fs.config=/config/path
+edc.tenants.tenant3.edc.fs.config=/config/path
+```
+
+Using this file the EDC will run with 3 tenants: `tenant1`, `tenant2` and `tenant3`, every one with their respective
+configuration file.
+Everything that stays after the tenant name in the setting key will be loaded in the tenant runtime, so *theoretically*
+(but not recommended) you could define all the tenants configuration in the tenants properties file:
+```properties
+edc.tenants.tenant1.web.http.port=18181
+edc.tenants.tenant1.any.other.setting=value
+edc.tenants.tenant2.web.http.port=28181
+edc.tenants.tenant3.web.http.port=38181
+```

--- a/edc-extensions/multi-tenancy/pom.xml
+++ b/edc-extensions/multi-tenancy/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0
+
+  SPDX-License-Identifier: Apache-2.0
+
+  Contributors:
+       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial POM
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.eclipse.tractusx.edc.extensions</groupId>
+        <artifactId>edc-extensions</artifactId>
+        <version>0.1.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>multi-tenancy</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <sonar.moduleKey>${project.groupId}_${project.artifactId}</sonar.moduleKey>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>../..</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>NOTICE.md</include>
+                    <include>LICENSE</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.dataspaceconnector</groupId>
+            <artifactId>core-boot</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dataspaceconnector</groupId>
+            <artifactId>core-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/edc-extensions/multi-tenancy/src/test/java/org/eclipse/tractusx/edc/boot/runtime/MultiTenantRuntimeTest.java
+++ b/edc-extensions/multi-tenancy/src/test/java/org/eclipse/tractusx/edc/boot/runtime/MultiTenantRuntimeTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.boot.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+
+class MultiTenantRuntimeTest {
+
+  private final Monitor monitor = mock(Monitor.class);
+  private final MultiTenantRuntime runtime =
+      new MultiTenantRuntime() {
+        @Override
+        protected @NotNull Monitor createMonitor() {
+          return monitor;
+        }
+      };
+
+  @Test
+  void throwsExceptionIfNoTenantsPropertyProvided() {
+    assertThrows(EdcException.class, runtime::boot);
+    verify(monitor, never()).info(argThat(connectorIsReady()));
+  }
+
+  @Test
+  void throwsExceptionIfTenantsFileDoesNotExist() {
+    System.setProperty("edc.tenants.path", "unexistentfile");
+
+    assertThrows(EdcException.class, runtime::boot);
+    verify(monitor, never()).info(argThat(connectorIsReady()));
+  }
+
+  @Test
+  void threadForEveryTenant() {
+    System.setProperty("edc.tenants.path", "./src/test/resources/tenants.properties");
+
+    runtime.boot();
+
+    verify(monitor, times(2)).info(argThat(connectorIsReady()));
+  }
+
+  @NotNull
+  private ArgumentMatcher<String> connectorIsReady() {
+    return message -> message.endsWith(" ready");
+  }
+}

--- a/edc-extensions/multi-tenancy/src/test/resources/tenants.properties
+++ b/edc-extensions/multi-tenancy/src/test/resources/tenants.properties
@@ -1,0 +1,2 @@
+edc.tenants.one.edc.any=any
+edc.tenants.two.edc.any=any

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>edc-controlplane</module>
         <module>edc-dataplane</module>
         <module>edc-tests</module>
+        <module>samples</module>
     </modules>
 
     <inceptionYear>2022</inceptionYear>
@@ -347,13 +348,13 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>net.catenax.edc.extensions</groupId>
-                <artifactId>xsuaa-authenticator</artifactId>
+                <groupId>org.eclipse.tractusx.edc.extensions</groupId>
+                <artifactId>cx-oauth2</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.tractusx.edc.extensions</groupId>
-                <artifactId>cx-oauth2</artifactId>
+                <artifactId>multi-tenancy</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -21,8 +21,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.tractusx.edc.extensions</groupId>
-    <artifactId>edc-extensions</artifactId>
+    <groupId>org.eclipse.tractusx.edc.samples</groupId>
+    <artifactId>samples</artifactId>
     <packaging>pom</packaging>
 
     <properties>
@@ -30,13 +30,7 @@
     </properties>
 
     <modules>
-        <module>business-partner-validation</module>
-        <module>cx-oauth2</module>
-        <module>data-encryption</module>
-        <module>dataplane-selector-configuration</module>
-        <module>hashicorp-vault</module>
-        <module>multi-tenancy</module>
-        <module>postgresql-migration</module>
+        <module>sample-multi-tenancy</module>
     </modules>
 
 </project>

--- a/samples/sample-multi-tenancy/README.md
+++ b/samples/sample-multi-tenancy/README.md
@@ -1,0 +1,47 @@
+# Sample Multi Tenancy
+
+Build:
+```shell
+./mvnw -pl samples/sample-multi-tenancy -am package
+```
+
+Run:
+```shell
+java -jar -Dedc.tenants.path=samples/sample-multi-tenancy/tenants.properties samples/sample-multi-tenancy/target/sample-multi-tenancy.jar
+```
+
+Create an asset on `first` tenant:
+```shell
+curl -X POST http://localhost:18181/api/assets \
+    --header 'X-Api-Key: password' \
+    --header 'Content-Type: application/json' \
+    --data '{
+             "asset": {
+                "properties": {
+                        "asset:prop:id": "1",
+                        "asset:prop:description": "Product EDC Demo Asset"
+                    }
+                },
+                "dataAddress": {
+                    "properties": {
+                        "type": "HttpData",
+                        "baseUrl": "https://jsonplaceholder.typicode.com/todos/1"
+                    }
+                }
+            }'
+```
+
+Get `first` tenant assets:
+```
+curl -X GET http://localhost:18181/api/assets
+[{"createdAt":1666075635217,"properties":{"asset:prop:description":"Product EDC Demo Asset","asset:prop:id":"1"},"id":"1"}]
+```
+
+`second` and `third` tenants will have no assets:
+```shell
+curl -X GET http://localhost:28181/api/assets
+[]
+
+curl -X GET http://localhost:38181/api/assets
+[]
+```

--- a/samples/sample-multi-tenancy/config/first.properties
+++ b/samples/sample-multi-tenancy/config/first.properties
@@ -1,0 +1,5 @@
+web.http.port=18181
+web.http.path=/api
+web.http.ids.port=18282
+web.http.ids.path=/api/v1/ids
+ids.webhook.address=http://localhost:18282

--- a/samples/sample-multi-tenancy/config/second.properties
+++ b/samples/sample-multi-tenancy/config/second.properties
@@ -1,0 +1,5 @@
+web.http.port=28181
+web.http.path=/api
+web.http.ids.port=28282
+web.http.ids.path=/api/v1/ids
+ids.webhook.address=http://localhost:28282

--- a/samples/sample-multi-tenancy/config/third.properties
+++ b/samples/sample-multi-tenancy/config/third.properties
@@ -1,0 +1,5 @@
+web.http.port=38181
+web.http.path=/api
+web.http.ids.port=38282
+web.http.ids.path=/api/v1/ids
+ids.webhook.address=http://localhost:38282

--- a/samples/sample-multi-tenancy/pom.xml
+++ b/samples/sample-multi-tenancy/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0
+
+  SPDX-License-Identifier: Apache-2.0
+
+  Contributors:
+       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial POM
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.eclipse.tractusx.edc.samples</groupId>
+        <artifactId>samples</artifactId>
+        <version>0.1.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sample-multi-tenancy</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <sonar.moduleKey>${project.groupId}_${project.artifactId}</sonar.moduleKey>
+    </properties>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>../../edc-extensions</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>NOTICE.md</include>
+                    <include>LICENSE</include>
+                </includes>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                            <mainClass>
+                                org.eclipse.tractusx.edc.boot.runtime.MultiTenantRuntime
+                            </mainClass>
+                            <useUniqueVersions>false</useUniqueVersions>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.tractusx.edc.extensions</groupId>
+            <artifactId>multi-tenancy</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.dataspaceconnector</groupId>
+            <artifactId>core-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dataspaceconnector</groupId>
+            <artifactId>control-plane-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dataspaceconnector</groupId>
+            <artifactId>filesystem-configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dataspaceconnector</groupId>
+            <artifactId>iam-mock</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dataspaceconnector</groupId>
+            <artifactId>data-management-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dataspaceconnector</groupId>
+            <artifactId>observability-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dataspaceconnector</groupId>
+            <artifactId>ids</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/samples/sample-multi-tenancy/tenants.properties
+++ b/samples/sample-multi-tenancy/tenants.properties
@@ -1,0 +1,3 @@
+edc.tenants.first.edc.fs.config=samples/sample-multi-tenancy/config/first.properties
+edc.tenants.second.edc.fs.config=samples/sample-multi-tenancy/config/second.properties
+edc.tenants.third.edc.fs.config=samples/sample-multi-tenancy/config/third.properties


### PR DESCRIPTION
## what
Provides `multi-tenancy` extension with a `MultiTenantRuntime` class, that can be used to run a multi-tenant EDC

## why
This is a requirement for PI6

## notes
- I created a `samples` folder containing a sample that shows how the multi-tenancy could be used