### PR TITLE
disable postgresql in charts/tractusx-connector per default

### DIFF
--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -451,7 +451,7 @@ dataplane:
     public: ""
 
 postgresql:
-  enabled: true
+  enabled: false
   jdbcUrl: ""
   username: ""
   password: ""


### PR DESCRIPTION
Signed-off-by: Dominik Pinsel <dominik.pinsel@daimler.com>