### PR TITLE
Increase trivy timeout

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -89,6 +89,7 @@ jobs:
           output: "trivy-results-${{ matrix.image }}.sarif"
           exit-code: "1"
           severity: "CRITICAL,HIGH"
+          timeout: "10m0s"
       -
         name: Upload Trivy scan results to GitHub Security tab
         if: always()


### PR DESCRIPTION
Seems like the Trivy action workflow breaks really often:
https://github.com/catenax-ng/product-edc/actions/workflows/trivy.yml

A lot of these failures report this error:
```log
WARN	Increase --timeout value
FATAL	image scan error: scan error: scan failed: failed analysis: analyze error: timeout: context deadline exceeded
``` 

According to [the documentation](https://github.com/aquasecurity/trivy-action) the default timeout is 5m, this PR will raise it to 10m