### PR TITLE
bugfix: Use /dev/urandom instead of /dev/.urandom

### DIFF
--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
@@ -64,6 +64,6 @@ CMD ["java", \
      "-Dotel.javaagent.configuration-file=/app/opentelemetry.properties", \
      "-Dotel.metrics.exporter=prometheus", \
      "-Dotel.exporter.prometheus.port=9090", \
-     "-Djava.security.edg=file:/dev/.urandom", \
+     "-Djava.security.edg=file:/dev/urandom", \
      "-jar", \
      "edc-controlplane.jar"]

--- a/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
@@ -64,6 +64,6 @@ CMD ["java", \
      "-Dotel.javaagent.configuration-file=/app/opentelemetry.properties", \
      "-Dotel.metrics.exporter=prometheus", \
      "-Dotel.exporter.prometheus.port=9090", \
-     "-Djava.security.edg=file:/dev/.urandom", \
+     "-Djava.security.edg=file:/dev/urandom", \
      "-jar", \
      "edc-controlplane.jar"]

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
@@ -64,6 +64,6 @@ CMD ["java", \
      "-Dotel.javaagent.configuration-file=/app/opentelemetry.properties", \
      "-Dotel.metrics.exporter=prometheus", \
      "-Dotel.exporter.prometheus.port=9090", \
-     "-Djava.security.edg=file:/dev/.urandom", \
+     "-Djava.security.edg=file:/dev/urandom", \
      "-jar", \
      "edc-controlplane.jar"]

--- a/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
@@ -64,6 +64,6 @@ CMD ["java", \
      "-Dotel.javaagent.configuration-file=/app/opentelemetry.properties", \
      "-Dotel.metrics.exporter=prometheus", \
      "-Dotel.exporter.prometheus.port=9090", \
-     "-Djava.security.edg=file:/dev/.urandom", \
+     "-Djava.security.edg=file:/dev/urandom", \
      "-jar", \
      "edc-controlplane.jar"]

--- a/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
@@ -64,6 +64,6 @@ CMD ["java", \
      "-Dotel.javaagent.configuration-file=/app/opentelemetry.properties", \
      "-Dotel.metrics.exporter=prometheus", \
      "-Dotel.exporter.prometheus.port=9090", \
-     "-Djava.security.edg=file:/dev/.urandom", \
+     "-Djava.security.edg=file:/dev/urandom", \
      "-jar", \
      "edc-dataplane.jar"]

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
@@ -64,6 +64,6 @@ CMD ["java", \
      "-Dotel.javaagent.configuration-file=/app/opentelemetry.properties", \
      "-Dotel.metrics.exporter=prometheus", \
      "-Dotel.exporter.prometheus.port=9090", \
-     "-Djava.security.edg=file:/dev/.urandom", \
+     "-Djava.security.edg=file:/dev/urandom", \
      "-jar", \
      "edc-dataplane.jar"]


### PR DESCRIPTION
The old path was used as a workaround and should not be necessary after Java 8. (https://www.baeldung.com/java-security-egd)

Relates to: https://jira.catena-x.net/browse/A1IDSC-410