### PR TITLE
refactor: Refactor usage of SecureRandom in data-encryption extension

### DIFF
--- a/edc-extensions/data-encryption/src/main/java/org/eclipse/tractusx/edc/data/encryption/algorithms/aes/AesInitializationVectorIterator.java
+++ b/edc-extensions/data-encryption/src/main/java/org/eclipse/tractusx/edc/data/encryption/algorithms/aes/AesInitializationVectorIterator.java
@@ -22,19 +22,20 @@ package org.eclipse.tractusx.edc.data.encryption.algorithms.aes;
 import java.security.SecureRandom;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import lombok.SneakyThrows;
 import org.eclipse.tractusx.edc.data.encryption.util.ArrayUtil;
 
 public class AesInitializationVectorIterator implements Iterator<byte[]> {
 
   public static final int RANDOM_SIZE = 12;
   public static final int COUNTER_SIZE = 4;
-  public static final int VECTOR_SIZE = RANDOM_SIZE + COUNTER_SIZE;
 
   private final ByteCounter counter;
 
-  public AesInitializationVectorIterator() {
-    counter = new ByteCounter(COUNTER_SIZE);
+  private SecureRandom secureRandom;
+
+  public AesInitializationVectorIterator(SecureRandom secureRandom) {
+    this.counter = new ByteCounter(COUNTER_SIZE);
+    this.secureRandom = secureRandom;
   }
 
   public AesInitializationVectorIterator(ByteCounter byteCounter) {
@@ -58,11 +59,9 @@ public class AesInitializationVectorIterator implements Iterator<byte[]> {
     return ArrayUtil.concat(random, counter.getBytes());
   }
 
-  @SneakyThrows
   public byte[] getNextRandom() {
-    SecureRandom random = SecureRandom.getInstanceStrong();
     byte[] newVector = new byte[RANDOM_SIZE];
-    random.nextBytes(newVector);
+    secureRandom.nextBytes(newVector);
     return newVector;
   }
 }

--- a/edc-extensions/data-encryption/src/test/java/org/eclipse/tractusx/edc/data/encryption/algorithms/aes/AesInitializationVectorIteratorTest.java
+++ b/edc-extensions/data-encryption/src/test/java/org/eclipse/tractusx/edc/data/encryption/algorithms/aes/AesInitializationVectorIteratorTest.java
@@ -19,6 +19,7 @@
  */
 package org.eclipse.tractusx.edc.data.encryption.algorithms.aes;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -34,7 +35,8 @@ class AesInitializationVectorIteratorTest {
   @SneakyThrows
   void testDistinctVectors() {
     final int vectorCount = 100;
-    AesInitializationVectorIterator iterator = new AesInitializationVectorIterator();
+    final SecureRandom secureRandom = SecureRandom.getInstanceStrong();
+    AesInitializationVectorIterator iterator = new AesInitializationVectorIterator(secureRandom);
 
     List<byte[]> vectors = new ArrayList<>();
     for (var i = 0; i < vectorCount; i++) {


### PR DESCRIPTION
As pointed out in #711 on each AES vector iteration a new instance of `SecureRandom` was established which is not necessary. This PR refactors that.

Relates to: https://jira.catena-x.net/browse/A1IDSC-410