### PR TITLE
Add contract id to data source http call

### DIFF
--- a/edc-controlplane/edc-controlplane-base/pom.xml
+++ b/edc-controlplane/edc-controlplane-base/pom.xml
@@ -77,6 +77,10 @@
             <groupId>org.eclipse.tractusx.edc.extensions</groupId>
             <artifactId>control-plane-adapter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.tractusx.edc.extensions</groupId>
+            <artifactId>provision-additional-headers</artifactId>
+        </dependency>
 
         <!-- Core -->
         <dependency>

--- a/edc-extensions/pom.xml
+++ b/edc-extensions/pom.xml
@@ -43,6 +43,7 @@
         <module>data-encryption</module>
         <module>control-plane-adapter</module>
         <module>cx-oauth2</module>
+        <module>provision-additional-headers</module>
         <module>transferprocess-sftp-common</module>
         <module>transferprocess-sftp-client</module>
         <module>transferprocess-sftp-provisioner</module>

--- a/edc-extensions/provision-additional-headers/README.md
+++ b/edc-extensions/provision-additional-headers/README.md
@@ -1,0 +1,6 @@
+# Provision: additional headers
+
+The goal of this extension is to provide additional headers to the request to the backend service done by the provider
+to retrieve the data to be given to the consumer.
+
+This is done to give the possibility to the provider backend service to audit the data requests.

--- a/edc-extensions/provision-additional-headers/README.md
+++ b/edc-extensions/provision-additional-headers/README.md
@@ -6,4 +6,4 @@ in order to retrieve the data that will be given to the consumer.
 This gives for example the provider backend service the possibility to audit the data requests.
 
 The following headers are added to the `HttpDataAddress`:
-- `Edc-Contract-Id`: the id of the contract agreement
+- `Edc-Contract-Agreement-Id`: the id of the contract agreement

--- a/edc-extensions/provision-additional-headers/README.md
+++ b/edc-extensions/provision-additional-headers/README.md
@@ -1,9 +1,9 @@
 # Provision: additional headers
 
 The goal of this extension is to provide additional headers to the request to the backend service done by the provider
-to retrieve the data to be given to the consumer.
+in order to retrieve the data that will be given to the consumer.
 
-This is done to give the possibility to the provider backend service to audit the data requests.
+This gives for example the provider backend service the possibility to audit the data requests.
 
 The following headers are added to the `HttpDataAddress`:
 - `Edc-Contract-Id`: the id of the contract agreement

--- a/edc-extensions/provision-additional-headers/README.md
+++ b/edc-extensions/provision-additional-headers/README.md
@@ -4,3 +4,6 @@ The goal of this extension is to provide additional headers to the request to th
 to retrieve the data to be given to the consumer.
 
 This is done to give the possibility to the provider backend service to audit the data requests.
+
+The following headers are added to the `HttpDataAddress`:
+- `Edc-Contract-Id`: the id of the contract agreement

--- a/edc-extensions/provision-additional-headers/pom.xml
+++ b/edc-extensions/provision-additional-headers/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>edc-extensions</artifactId>
+        <groupId>org.eclipse.tractusx.edc.extensions</groupId>
+        <version>0.2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>provision-additional-headers</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <originalSourceDirectory>${project.basedir}/src/main/java</originalSourceDirectory>
+        <sourceDirectory>${originalSourceDirectory}</sourceDirectory>
+        <delombokSourceDirectory>${project.build.directory}/delombok</delombokSourceDirectory>
+        <sonar.moduleKey>${project.groupId}_${project.artifactId}</sonar.moduleKey>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${org.projectlombok.lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-maven-plugin</artifactId>
+                <version>${org.projectlombok.lombok.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>delombok</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDirectory>${originalSourceDirectory}</sourceDirectory>
+                    <outputDirectory>${delombokSourceDirectory}</outputDirectory>
+                    <addOutputDirectory>false</addOutputDirectory>
+                    <encoding>UTF-8</encoding>
+                    <formatPreferences>
+                        <javaLangAsFQN>skip</javaLangAsFQN>
+                    </formatPreferences>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- SPI -->
+        <dependency>
+            <groupId>org.eclipse.edc</groupId>
+            <artifactId>core-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.edc</groupId>
+            <artifactId>transfer-spi</artifactId>
+        </dependency>
+
+        <!-- External Dependencies -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <!-- patch versions -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.eclipse.edc</groupId>
+            <artifactId>control-plane-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.edc</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/edc-extensions/provision-additional-headers/pom.xml
+++ b/edc-extensions/provision-additional-headers/pom.xml
@@ -114,14 +114,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>nimbus-jose-jwt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
 
         <!-- patch versions -->
         <dependency>

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionedResource.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionedResource.java
@@ -1,0 +1,24 @@
+package org.eclipse.tractusx.edc.provision.additionalheaders;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedContentResource;
+
+@JsonDeserialize(builder = Builder.class)
+class AdditionalHeadersProvisionedResource extends ProvisionedContentResource {
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProvisionedContentResource.Builder<AdditionalHeadersProvisionedResource, Builder> {
+
+        private Builder() {
+            super(new AdditionalHeadersProvisionedResource());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+    }
+}

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionedResource.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionedResource.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -5,20 +25,20 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.connector.transfer.spi.types.ProvisionedContentResource;
 
-@JsonDeserialize(builder = Builder.class)
+@JsonDeserialize(builder = AdditionalHeadersProvisionedResource.Builder.class)
 class AdditionalHeadersProvisionedResource extends ProvisionedContentResource {
 
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder extends ProvisionedContentResource.Builder<AdditionalHeadersProvisionedResource, Builder> {
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class Builder
+      extends ProvisionedContentResource.Builder<AdditionalHeadersProvisionedResource, Builder> {
 
-        private Builder() {
-            super(new AdditionalHeadersProvisionedResource());
-        }
-
-        @JsonCreator
-        public static Builder newInstance() {
-            return new Builder();
-        }
-
+    private Builder() {
+      super(new AdditionalHeadersProvisionedResource());
     }
+
+    @JsonCreator
+    public static Builder newInstance() {
+      return new Builder();
+    }
+  }
 }

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
@@ -52,7 +52,7 @@ public class AdditionalHeadersProvisioner
     var address =
         HttpDataAddress.Builder.newInstance()
             .copyFrom(resourceDefinition.getDataAddress())
-            .addAdditionalHeader("Edc-Contract-Id", resourceDefinition.getContractId())
+            .addAdditionalHeader("Edc-Contract-Agreement-Id", resourceDefinition.getContractId())
             .build();
 
     var provisioned =

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
@@ -1,5 +1,27 @@
+/*
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.eclipse.edc.connector.transfer.spi.provision.Provisioner;
 import org.eclipse.edc.connector.transfer.spi.types.DeprovisionedResource;
 import org.eclipse.edc.connector.transfer.spi.types.ProvisionResponse;
@@ -9,47 +31,48 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.HttpDataAddress;
 
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
+public class AdditionalHeadersProvisioner
+    implements Provisioner<
+        AdditionalHeadersResourceDefinition, AdditionalHeadersProvisionedResource> {
 
-public class AdditionalHeadersProvisioner implements Provisioner<AdditionalHeadersResourceDefinition, AdditionalHeadersProvisionedResource> {
+  @Override
+  public boolean canProvision(ResourceDefinition resourceDefinition) {
+    return resourceDefinition instanceof AdditionalHeadersResourceDefinition;
+  }
 
-    @Override
-    public boolean canProvision(ResourceDefinition resourceDefinition) {
-        return resourceDefinition instanceof AdditionalHeadersResourceDefinition;
-    }
+  @Override
+  public boolean canDeprovision(ProvisionedResource provisionedResource) {
+    return false; // nothing to deprovision
+  }
 
-    @Override
-    public boolean canDeprovision(ProvisionedResource provisionedResource) {
-        return false; // nothing to deprovision
-    }
+  @Override
+  public CompletableFuture<StatusResult<ProvisionResponse>> provision(
+      AdditionalHeadersResourceDefinition resourceDefinition, Policy policy) {
 
-    @Override
-    public CompletableFuture<StatusResult<ProvisionResponse>> provision(AdditionalHeadersResourceDefinition resourceDefinition, Policy policy) {
+    var address =
+        HttpDataAddress.Builder.newInstance()
+            .copyFrom(resourceDefinition.getDataAddress())
+            .addAdditionalHeader("Edc-Contract-Id", resourceDefinition.getContractId())
+            .build();
 
-        var address = HttpDataAddress.Builder.newInstance()
-                .copyFrom(resourceDefinition.getDataAddress())
-                .addAdditionalHeader("Edc-Contract-Id", resourceDefinition.getContractId())
-                .build();
+    var provisioned =
+        AdditionalHeadersProvisionedResource.Builder.newInstance()
+            .id(UUID.randomUUID().toString())
+            .resourceDefinitionId(resourceDefinition.getId())
+            .transferProcessId(resourceDefinition.getTransferProcessId())
+            .dataAddress(address)
+            .resourceName(UUID.randomUUID().toString()) // TODO: why is this mandatory?
+            .hasToken(false)
+            .build();
 
-        var provisioned = AdditionalHeadersProvisionedResource.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .resourceDefinitionId(resourceDefinition.getId())
-                .transferProcessId(resourceDefinition.getTransferProcessId())
-                .dataAddress(address)
-                .resourceName(UUID.randomUUID().toString()) // TODO: why is this mandatory?
-                .hasToken(false)
-                .build();
+    var response = ProvisionResponse.Builder.newInstance().resource(provisioned).build();
+    var result = StatusResult.success(response);
+    return CompletableFuture.completedFuture(result);
+  }
 
-        var response = ProvisionResponse.Builder.newInstance()
-                .resource(provisioned)
-                .build();
-        var result = StatusResult.success(response);
-        return CompletableFuture.completedFuture(result);
-    }
-
-    @Override
-    public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(AdditionalHeadersProvisionedResource additionalHeadersProvisionedResource, Policy policy) {
-        return null; //nothing to deprovision
-    }
+  @Override
+  public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(
+      AdditionalHeadersProvisionedResource additionalHeadersProvisionedResource, Policy policy) {
+    return null; // nothing to deprovision
+  }
 }

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
@@ -1,0 +1,55 @@
+package org.eclipse.tractusx.edc.provision.additionalheaders;
+
+import org.eclipse.edc.connector.transfer.spi.provision.Provisioner;
+import org.eclipse.edc.connector.transfer.spi.types.DeprovisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionResponse;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.HttpDataAddress;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class AdditionalHeadersProvisioner implements Provisioner<AdditionalHeadersResourceDefinition, AdditionalHeadersProvisionedResource> {
+
+    @Override
+    public boolean canProvision(ResourceDefinition resourceDefinition) {
+        return resourceDefinition instanceof AdditionalHeadersResourceDefinition;
+    }
+
+    @Override
+    public boolean canDeprovision(ProvisionedResource provisionedResource) {
+        return false; // nothing to deprovision
+    }
+
+    @Override
+    public CompletableFuture<StatusResult<ProvisionResponse>> provision(AdditionalHeadersResourceDefinition resourceDefinition, Policy policy) {
+
+        var address = HttpDataAddress.Builder.newInstance()
+                .copyFrom(resourceDefinition.getDataAddress())
+                .addAdditionalHeader("Edc-Contract-Id", resourceDefinition.getContractId())
+                .build();
+
+        var provisioned = AdditionalHeadersProvisionedResource.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .resourceDefinitionId(resourceDefinition.getId())
+                .transferProcessId(resourceDefinition.getTransferProcessId())
+                .dataAddress(address)
+                .resourceName(UUID.randomUUID().toString()) // TODO: why is this mandatory?
+                .hasToken(false)
+                .build();
+
+        var response = ProvisionResponse.Builder.newInstance()
+                .resource(provisioned)
+                .build();
+        var result = StatusResult.success(response);
+        return CompletableFuture.completedFuture(result);
+    }
+
+    @Override
+    public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(AdditionalHeadersProvisionedResource additionalHeadersProvisionedResource, Policy policy) {
+        return null; //nothing to deprovision
+    }
+}

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
@@ -61,7 +61,7 @@ public class AdditionalHeadersProvisioner
             .resourceDefinitionId(resourceDefinition.getId())
             .transferProcessId(resourceDefinition.getTransferProcessId())
             .dataAddress(address)
-            .resourceName(UUID.randomUUID().toString()) // TODO: why is this mandatory?
+            .resourceName(UUID.randomUUID().toString())
             .hasToken(false)
             .build();
 

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinition.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinition.java
@@ -21,12 +21,14 @@
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
 @JsonDeserialize(builder = AdditionalHeadersResourceDefinition.Builder.class)
+@JsonTypeName("dataspaceconnector:additionalheadersresourcedefinition")
 class AdditionalHeadersResourceDefinition extends ResourceDefinition {
 
   private String contractId;

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinition.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinition.java
@@ -1,0 +1,48 @@
+package org.eclipse.tractusx.edc.provision.additionalheaders;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+@JsonPOJOBuilder(withPrefix = "")
+class AdditionalHeadersResourceDefinition extends ResourceDefinition {
+
+    private String contractId;
+    private DataAddress dataAddress;
+
+    @Override
+    public Builder toBuilder() {
+        return initializeBuilder(new Builder());
+    }
+
+    public DataAddress getDataAddress() {
+        return dataAddress;
+    }
+
+    public String getContractId() {
+        return contractId;
+    }
+
+    public static class Builder extends ResourceDefinition.Builder<AdditionalHeadersResourceDefinition, Builder> {
+
+        protected Builder() {
+            super(new AdditionalHeadersResourceDefinition());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder contractId(String contractId) {
+            this.resourceDefinition.contractId = contractId;
+            return this;
+        }
+
+        public Builder dataAddress(DataAddress dataAddress) {
+            this.resourceDefinition.dataAddress = dataAddress;
+            return this;
+        }
+    }
+}

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinition.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinition.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -8,41 +28,42 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 @JsonPOJOBuilder(withPrefix = "")
 class AdditionalHeadersResourceDefinition extends ResourceDefinition {
 
-    private String contractId;
-    private DataAddress dataAddress;
+  private String contractId;
+  private DataAddress dataAddress;
 
-    @Override
-    public Builder toBuilder() {
-        return initializeBuilder(new Builder());
+  @Override
+  public Builder toBuilder() {
+    return initializeBuilder(new Builder());
+  }
+
+  public DataAddress getDataAddress() {
+    return dataAddress;
+  }
+
+  public String getContractId() {
+    return contractId;
+  }
+
+  public static class Builder
+      extends ResourceDefinition.Builder<AdditionalHeadersResourceDefinition, Builder> {
+
+    protected Builder() {
+      super(new AdditionalHeadersResourceDefinition());
     }
 
-    public DataAddress getDataAddress() {
-        return dataAddress;
+    @JsonCreator
+    public static Builder newInstance() {
+      return new Builder();
     }
 
-    public String getContractId() {
-        return contractId;
+    public Builder contractId(String contractId) {
+      this.resourceDefinition.contractId = contractId;
+      return this;
     }
 
-    public static class Builder extends ResourceDefinition.Builder<AdditionalHeadersResourceDefinition, Builder> {
-
-        protected Builder() {
-            super(new AdditionalHeadersResourceDefinition());
-        }
-
-        @JsonCreator
-        public static Builder newInstance() {
-            return new Builder();
-        }
-
-        public Builder contractId(String contractId) {
-            this.resourceDefinition.contractId = contractId;
-            return this;
-        }
-
-        public Builder dataAddress(DataAddress dataAddress) {
-            this.resourceDefinition.dataAddress = dataAddress;
-            return this;
-        }
+    public Builder dataAddress(DataAddress dataAddress) {
+      this.resourceDefinition.dataAddress = dataAddress;
+      return this;
     }
+  }
 }

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinition.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinition.java
@@ -21,11 +21,12 @@
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
-@JsonPOJOBuilder(withPrefix = "")
+@JsonDeserialize(builder = AdditionalHeadersResourceDefinition.Builder.class)
 class AdditionalHeadersResourceDefinition extends ResourceDefinition {
 
   private String contractId;
@@ -44,6 +45,7 @@ class AdditionalHeadersResourceDefinition extends ResourceDefinition {
     return contractId;
   }
 
+  @JsonPOJOBuilder(withPrefix = "")
   public static class Builder
       extends ResourceDefinition.Builder<AdditionalHeadersResourceDefinition, Builder> {
 

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionGenerator.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionGenerator.java
@@ -1,5 +1,26 @@
+/*
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
+import java.util.UUID;
 import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
@@ -7,20 +28,20 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
-
 class AdditionalHeadersResourceDefinitionGenerator implements ProviderResourceDefinitionGenerator {
-    @Override
-    public @Nullable ResourceDefinition generate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
-        return AdditionalHeadersResourceDefinition.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .dataAddress(dataAddress)
-                .contractId(dataRequest.getContractId())
-                .build();
-    }
 
-    @Override
-    public boolean canGenerate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
-        return "HttpData".equals(dataAddress.getType());
-    }
+  @Override
+  public @Nullable ResourceDefinition generate(
+      DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
+    return AdditionalHeadersResourceDefinition.Builder.newInstance()
+        .id(UUID.randomUUID().toString())
+        .dataAddress(dataAddress)
+        .contractId(dataRequest.getContractId())
+        .build();
+  }
+
+  @Override
+  public boolean canGenerate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
+    return "HttpData".equals(dataAddress.getType());
+  }
 }

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionGenerator.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionGenerator.java
@@ -1,0 +1,26 @@
+package org.eclipse.tractusx.edc.provision.additionalheaders;
+
+import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
+import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+class AdditionalHeadersResourceDefinitionGenerator implements ProviderResourceDefinitionGenerator {
+    @Override
+    public @Nullable ResourceDefinition generate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
+        return AdditionalHeadersResourceDefinition.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .dataAddress(dataAddress)
+                .contractId(dataRequest.getContractId())
+                .build();
+    }
+
+    @Override
+    public boolean canGenerate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
+        return "HttpData".equals(dataAddress.getType());
+    }
+}

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
@@ -3,22 +3,12 @@ package org.eclipse.tractusx.edc.provision.additionalheaders;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
-import org.eclipse.edc.connector.transfer.spi.provision.Provisioner;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
 import org.eclipse.edc.connector.transfer.spi.types.*;
-import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.HttpDataAddress;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 public class ProvisionAdditionalHeadersExtension implements ServiceExtension {
 
@@ -34,120 +24,4 @@ public class ProvisionAdditionalHeadersExtension implements ServiceExtension {
         provisionManager.register(new AdditionalHeadersProvisioner());
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
-    private static class AdditionalHeadersResourceDefinition extends ResourceDefinition {
-
-        private String contractId;
-        private DataAddress dataAddress;
-
-        @Override
-        public Builder toBuilder() {
-            return initializeBuilder(new Builder());
-        }
-
-        public DataAddress getDataAddress() {
-            return dataAddress;
-        }
-
-        public String getContractId() {
-            return contractId;
-        }
-
-        public static class Builder extends ResourceDefinition.Builder<AdditionalHeadersResourceDefinition, Builder> {
-
-            protected Builder() {
-                super(new AdditionalHeadersResourceDefinition());
-            }
-
-            @JsonCreator
-            public static Builder newInstance() {
-                return new Builder();
-            }
-
-            public Builder contractId(String contractId) {
-                this.resourceDefinition.contractId = contractId;
-                return this;
-            }
-
-            public Builder dataAddress(DataAddress dataAddress) {
-                this.resourceDefinition.dataAddress = dataAddress;
-                return this;
-            }
-        }
-    }
-
-    private static class AdditionalHeadersResourceDefinitionGenerator implements ProviderResourceDefinitionGenerator {
-        @Override
-        public @Nullable ResourceDefinition generate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
-            return AdditionalHeadersResourceDefinition.Builder.newInstance()
-                    .id(UUID.randomUUID().toString())
-                    .dataAddress(dataAddress)
-                    .contractId(dataRequest.getContractId())
-                    .build();
-        }
-
-        @Override
-        public boolean canGenerate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
-            return "HttpData".equals(dataAddress.getType());
-        }
-    }
-
-    private class AdditionalHeadersProvisioner implements Provisioner<AdditionalHeadersResourceDefinition, AdditionalHeadersProvisionedResource> {
-        @Override
-        public boolean canProvision(ResourceDefinition resourceDefinition) {
-            return resourceDefinition instanceof AdditionalHeadersResourceDefinition;
-        }
-
-        @Override
-        public boolean canDeprovision(ProvisionedResource provisionedResource) {
-            return false; // nothing to deprovision
-        }
-
-        @Override
-        public CompletableFuture<StatusResult<ProvisionResponse>> provision(AdditionalHeadersResourceDefinition resourceDefinition, Policy policy) {
-
-            var address = HttpDataAddress.Builder.newInstance()
-                    .copyFrom(resourceDefinition.getDataAddress())
-                    .addAdditionalHeader("Edc-Contract-Id", resourceDefinition.getContractId())
-                    .build();
-
-            var provisioned = AdditionalHeadersProvisionedResource.Builder.newInstance()
-                    .id(UUID.randomUUID().toString())
-                    .resourceDefinitionId(resourceDefinition.getId())
-                    .transferProcessId(resourceDefinition.getTransferProcessId())
-                    .dataAddress(address)
-                    .resourceName(UUID.randomUUID().toString()) // TODO: why is this mandatory?
-                    .hasToken(false)
-                    .build();
-
-            var response = ProvisionResponse.Builder.newInstance()
-                    .resource(provisioned)
-                    .build();
-            var result = StatusResult.success(response);
-            return CompletableFuture.completedFuture(result);
-        }
-
-        @Override
-        public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(AdditionalHeadersProvisionedResource additionalHeadersProvisionedResource, Policy policy) {
-            return null; //nothing to deprovision
-        }
-    }
-
-    @JsonDeserialize(builder = AdditionalHeadersProvisionedResource.Builder.class)
-    private static class AdditionalHeadersProvisionedResource extends ProvisionedContentResource {
-
-        @JsonPOJOBuilder(withPrefix = "")
-        public static class Builder extends ProvisionedContentResource.Builder<AdditionalHeadersProvisionedResource, Builder> {
-
-            private Builder() {
-                super(new AdditionalHeadersProvisionedResource());
-            }
-
-            @JsonCreator
-            public static Builder newInstance() {
-                return new Builder();
-            }
-
-        }
-    }
 }

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
@@ -1,0 +1,153 @@
+package org.eclipse.tractusx.edc.provision.additionalheaders;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
+import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
+import org.eclipse.edc.connector.transfer.spi.provision.Provisioner;
+import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
+import org.eclipse.edc.connector.transfer.spi.types.*;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.HttpDataAddress;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class ProvisionAdditionalHeadersExtension implements ServiceExtension {
+
+    @Inject
+    private ResourceManifestGenerator resourceManifestGenerator;
+
+    @Inject
+    private ProvisionManager provisionManager;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        resourceManifestGenerator.registerGenerator(new AdditionalHeadersResourceDefinitionGenerator());
+        provisionManager.register(new AdditionalHeadersProvisioner());
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    private static class AdditionalHeadersResourceDefinition extends ResourceDefinition {
+
+        private String contractId;
+        private DataAddress dataAddress;
+
+        @Override
+        public Builder toBuilder() {
+            return initializeBuilder(new Builder());
+        }
+
+        public DataAddress getDataAddress() {
+            return dataAddress;
+        }
+
+        public String getContractId() {
+            return contractId;
+        }
+
+        public static class Builder extends ResourceDefinition.Builder<AdditionalHeadersResourceDefinition, Builder> {
+
+            protected Builder() {
+                super(new AdditionalHeadersResourceDefinition());
+            }
+
+            @JsonCreator
+            public static Builder newInstance() {
+                return new Builder();
+            }
+
+            public Builder contractId(String contractId) {
+                this.resourceDefinition.contractId = contractId;
+                return this;
+            }
+
+            public Builder dataAddress(DataAddress dataAddress) {
+                this.resourceDefinition.dataAddress = dataAddress;
+                return this;
+            }
+        }
+    }
+
+    private static class AdditionalHeadersResourceDefinitionGenerator implements ProviderResourceDefinitionGenerator {
+        @Override
+        public @Nullable ResourceDefinition generate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
+            return AdditionalHeadersResourceDefinition.Builder.newInstance()
+                    .id(UUID.randomUUID().toString())
+                    .dataAddress(dataAddress)
+                    .contractId(dataRequest.getContractId())
+                    .build();
+        }
+
+        @Override
+        public boolean canGenerate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
+            return "HttpData".equals(dataAddress.getType());
+        }
+    }
+
+    private class AdditionalHeadersProvisioner implements Provisioner<AdditionalHeadersResourceDefinition, AdditionalHeadersProvisionedResource> {
+        @Override
+        public boolean canProvision(ResourceDefinition resourceDefinition) {
+            return resourceDefinition instanceof AdditionalHeadersResourceDefinition;
+        }
+
+        @Override
+        public boolean canDeprovision(ProvisionedResource provisionedResource) {
+            return false; // nothing to deprovision
+        }
+
+        @Override
+        public CompletableFuture<StatusResult<ProvisionResponse>> provision(AdditionalHeadersResourceDefinition resourceDefinition, Policy policy) {
+
+            var address = HttpDataAddress.Builder.newInstance()
+                    .copyFrom(resourceDefinition.getDataAddress())
+                    .addAdditionalHeader("contractId", resourceDefinition.getContractId())
+                    .build();
+
+            var provisioned = AdditionalHeadersProvisionedResource.Builder.newInstance()
+                    .id(UUID.randomUUID().toString())
+                    .resourceDefinitionId(resourceDefinition.getId())
+                    .transferProcessId(resourceDefinition.getTransferProcessId())
+                    .dataAddress(address)
+                    .resourceName(UUID.randomUUID().toString()) // TODO: why this is mandatory?
+                    .hasToken(false)
+                    .build();
+
+            var response = ProvisionResponse.Builder.newInstance()
+                    .resource(provisioned)
+                    .build();
+            var result = StatusResult.success(response);
+            return CompletableFuture.completedFuture(result);
+        }
+
+        @Override
+        public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(AdditionalHeadersProvisionedResource additionalHeadersProvisionedResource, Policy policy) {
+            return null; //nothing to deprovision
+        }
+    }
+
+    @JsonDeserialize(builder = AdditionalHeadersProvisionedResource.Builder.class)
+    private static class AdditionalHeadersProvisionedResource extends ProvisionedContentResource {
+
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder extends ProvisionedContentResource.Builder<AdditionalHeadersProvisionedResource, Builder> {
+
+            private Builder() {
+                super(new AdditionalHeadersProvisionedResource());
+            }
+
+            @JsonCreator
+            public static Builder newInstance() {
+                return new Builder();
+            }
+
+        }
+    }
+}

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
@@ -108,7 +108,7 @@ public class ProvisionAdditionalHeadersExtension implements ServiceExtension {
 
             var address = HttpDataAddress.Builder.newInstance()
                     .copyFrom(resourceDefinition.getDataAddress())
-                    .addAdditionalHeader("contractId", resourceDefinition.getContractId())
+                    .addAdditionalHeader("Edc-Contract-Id", resourceDefinition.getContractId())
                     .build();
 
             var provisioned = AdditionalHeadersProvisionedResource.Builder.newInstance()
@@ -116,7 +116,7 @@ public class ProvisionAdditionalHeadersExtension implements ServiceExtension {
                     .resourceDefinitionId(resourceDefinition.getId())
                     .transferProcessId(resourceDefinition.getTransferProcessId())
                     .dataAddress(address)
-                    .resourceName(UUID.randomUUID().toString()) // TODO: why this is mandatory?
+                    .resourceName(UUID.randomUUID().toString()) // TODO: why is this mandatory?
                     .hasToken(false)
                     .build();
 

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
@@ -1,27 +1,40 @@
+/*
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
-import org.eclipse.edc.connector.transfer.spi.types.*;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
 public class ProvisionAdditionalHeadersExtension implements ServiceExtension {
 
-    @Inject
-    private ResourceManifestGenerator resourceManifestGenerator;
+  @Inject private ResourceManifestGenerator resourceManifestGenerator;
 
-    @Inject
-    private ProvisionManager provisionManager;
+  @Inject private ProvisionManager provisionManager;
 
-    @Override
-    public void initialize(ServiceExtensionContext context) {
-        resourceManifestGenerator.registerGenerator(new AdditionalHeadersResourceDefinitionGenerator());
-        provisionManager.register(new AdditionalHeadersProvisioner());
-    }
-
+  @Override
+  public void initialize(ServiceExtensionContext context) {
+    resourceManifestGenerator.registerGenerator(new AdditionalHeadersResourceDefinitionGenerator());
+    provisionManager.register(new AdditionalHeadersProvisioner());
+  }
 }

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerato
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 
 public class ProvisionAdditionalHeadersExtension implements ServiceExtension {
 
@@ -32,8 +33,12 @@ public class ProvisionAdditionalHeadersExtension implements ServiceExtension {
 
   @Inject private ProvisionManager provisionManager;
 
+  @Inject private TypeManager typeManager;
+
   @Override
   public void initialize(ServiceExtensionContext context) {
+    typeManager.registerTypes(
+        AdditionalHeadersResourceDefinition.class, AdditionalHeadersProvisionedResource.class);
     resourceManifestGenerator.registerGenerator(new AdditionalHeadersResourceDefinitionGenerator());
     provisionManager.register(new AdditionalHeadersProvisioner());
   }

--- a/edc-extensions/provision-additional-headers/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/provision-additional-headers/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,20 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+org.eclipse.tractusx.edc.provision.additionalheaders.ProvisionAdditionalHeadersExtension

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionedResourceTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionedResourceTest.java
@@ -20,28 +20,31 @@
 
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import java.util.UUID;
-import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
-import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
-import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
 
-class AdditionalHeadersResourceDefinitionGenerator implements ProviderResourceDefinitionGenerator {
+class AdditionalHeadersProvisionedResourceTest {
 
-  @Override
-  public boolean canGenerate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
-    return "HttpData".equals(dataAddress.getType());
-  }
+  @Test
+  void serdes() {
+    var typeManager = new TypeManager();
+    var resource =
+        AdditionalHeadersProvisionedResource.Builder.newInstance()
+            .id(UUID.randomUUID().toString())
+            .resourceDefinitionId(UUID.randomUUID().toString())
+            .transferProcessId(UUID.randomUUID().toString())
+            .hasToken(false)
+            .resourceName("name")
+            .dataAddress(DataAddress.Builder.newInstance().type("type").build())
+            .build();
 
-  @Override
-  public @Nullable ResourceDefinition generate(
-      DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
-    return AdditionalHeadersResourceDefinition.Builder.newInstance()
-        .id(UUID.randomUUID().toString())
-        .dataAddress(dataAddress)
-        .contractId(dataRequest.getContractId())
-        .build();
+    var json = typeManager.writeValueAsString(resource);
+    var deserialized = typeManager.readValue(json, AdditionalHeadersProvisionedResource.class);
+
+    assertThat(deserialized).usingRecursiveComparison().isEqualTo(resource);
   }
 }

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionerTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.provision.additionalheaders;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.map;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.mockito.Mockito.mock;
+
+import java.util.UUID;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionResponse;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedDataAddressResource;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.HttpDataAddress;
+import org.junit.jupiter.api.Test;
+
+class AdditionalHeadersProvisionerTest {
+
+  private final AdditionalHeadersProvisioner provisioner = new AdditionalHeadersProvisioner();
+
+  @Test
+  void canProvisionAdditionalHeadersResourceDefinition() {
+    assertThat(provisioner.canProvision(mock(AdditionalHeadersResourceDefinition.class))).isTrue();
+    assertThat(provisioner.canProvision(mock(ResourceDefinition.class))).isFalse();
+  }
+
+  @Test
+  void cannotDeprovisionAdditionalHeadersResourceDefinition() {
+    assertThat(provisioner.canDeprovision(mock(AdditionalHeadersProvisionedResource.class)))
+        .isFalse();
+    assertThat(provisioner.canDeprovision(mock(ProvisionedResource.class))).isFalse();
+  }
+
+  @Test
+  void shouldAddContractIdAdditionalHeader() {
+    var address = HttpDataAddress.Builder.newInstance().baseUrl("http://any").build();
+    var resourceDefinition =
+        AdditionalHeadersResourceDefinition.Builder.newInstance()
+            .id(UUID.randomUUID().toString())
+            .transferProcessId(UUID.randomUUID().toString())
+            .contractId("contractId")
+            .dataAddress(address)
+            .build();
+
+    var result = provisioner.provision(resourceDefinition, Policy.Builder.newInstance().build());
+
+    assertThat(result)
+        .succeedsWithin(5, SECONDS)
+        .matches(StatusResult::succeeded)
+        .extracting(StatusResult::getContent)
+        .extracting(ProvisionResponse::getResource)
+        .asInstanceOf(type(AdditionalHeadersProvisionedResource.class))
+        .extracting(ProvisionedDataAddressResource::getDataAddress)
+        .extracting(a -> HttpDataAddress.Builder.newInstance().copyFrom(a).build())
+        .extracting(HttpDataAddress::getAdditionalHeaders)
+        .asInstanceOf(map(String.class, String.class))
+        .containsEntry("Edc-Contract-Id", "contractId");
+  }
+}

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionerTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionerTest.java
@@ -76,6 +76,6 @@ class AdditionalHeadersProvisionerTest {
         .extracting(a -> HttpDataAddress.Builder.newInstance().copyFrom(a).build())
         .extracting(HttpDataAddress::getAdditionalHeaders)
         .asInstanceOf(map(String.class, String.class))
-        .containsEntry("Edc-Contract-Id", "contractId");
+        .containsEntry("Edc-Contract-Agreement-Id", "contractId");
   }
 }

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionGeneratorTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionGeneratorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.provision.additionalheaders;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+import java.util.UUID;
+import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.HttpDataAddress;
+import org.junit.jupiter.api.Test;
+
+class AdditionalHeadersResourceDefinitionGeneratorTest {
+
+  private final AdditionalHeadersResourceDefinitionGenerator generator =
+      new AdditionalHeadersResourceDefinitionGenerator();
+
+  @Test
+  void shouldIgnoreNotHttpDataAddresses() {
+    var dataAddress = DataAddress.Builder.newInstance().type("any").build();
+    var dataRequest =
+        DataRequest.Builder.newInstance()
+            .id(UUID.randomUUID().toString())
+            .dataDestination(dataAddress)
+            .build();
+    var build = Policy.Builder.newInstance().build();
+
+    var result = generator.canGenerate(dataRequest, dataAddress, build);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void shouldCreateResourceDefinitionWithDataAddress() {
+    var dataAddress = HttpDataAddress.Builder.newInstance().baseUrl("http://any").build();
+    var dataRequest =
+        DataRequest.Builder.newInstance()
+            .id(UUID.randomUUID().toString())
+            .dataDestination(dataAddress)
+            .build();
+    var build = Policy.Builder.newInstance().build();
+
+    var result = generator.generate(dataRequest, dataAddress, build);
+
+    assertThat(result)
+        .asInstanceOf(type(AdditionalHeadersResourceDefinition.class))
+        .extracting(AdditionalHeadersResourceDefinition::getDataAddress)
+        .extracting(address -> HttpDataAddress.Builder.newInstance().copyFrom(address).build())
+        .extracting(HttpDataAddress::getBaseUrl)
+        .isEqualTo("http://any");
+  }
+}

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionGeneratorTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionGeneratorTest.java
@@ -36,7 +36,7 @@ class AdditionalHeadersResourceDefinitionGeneratorTest {
       new AdditionalHeadersResourceDefinitionGenerator();
 
   @Test
-  void shouldIgnoreNotHttpDataAddresses() {
+  void canGenerate_shouldReturnFalseForNotHttpDataAddresses() {
     var dataAddress = DataAddress.Builder.newInstance().type("any").build();
     var dataRequest =
         DataRequest.Builder.newInstance()
@@ -48,6 +48,21 @@ class AdditionalHeadersResourceDefinitionGeneratorTest {
     var result = generator.canGenerate(dataRequest, dataAddress, build);
 
     assertThat(result).isFalse();
+  }
+
+  @Test
+  void canGenerate_shouldReturnTrueForHttpDataAddresses() {
+    var dataAddress = DataAddress.Builder.newInstance().type("HttpData").build();
+    var dataRequest =
+        DataRequest.Builder.newInstance()
+            .id(UUID.randomUUID().toString())
+            .dataDestination(dataAddress)
+            .build();
+    var build = Policy.Builder.newInstance().build();
+
+    var result = generator.canGenerate(dataRequest, dataAddress, build);
+
+    assertThat(result).isTrue();
   }
 
   @Test

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionTest.java
@@ -20,28 +20,29 @@
 
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import java.util.UUID;
-import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
-import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
-import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
 
-class AdditionalHeadersResourceDefinitionGenerator implements ProviderResourceDefinitionGenerator {
+class AdditionalHeadersResourceDefinitionTest {
 
-  @Override
-  public boolean canGenerate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
-    return "HttpData".equals(dataAddress.getType());
-  }
+  @Test
+  void serdes() {
+    var typeManager = new TypeManager();
+    var definition =
+        AdditionalHeadersResourceDefinition.Builder.newInstance()
+            .id(UUID.randomUUID().toString())
+            .transferProcessId(UUID.randomUUID().toString())
+            .dataAddress(DataAddress.Builder.newInstance().type("type").build())
+            .contractId(UUID.randomUUID().toString())
+            .build();
 
-  @Override
-  public @Nullable ResourceDefinition generate(
-      DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
-    return AdditionalHeadersResourceDefinition.Builder.newInstance()
-        .id(UUID.randomUUID().toString())
-        .dataAddress(dataAddress)
-        .contractId(dataRequest.getContractId())
-        .build();
+    var json = typeManager.writeValueAsString(definition);
+    var deserialized = typeManager.readValue(json, AdditionalHeadersResourceDefinition.class);
+
+    assertThat(deserialized).usingRecursiveComparison().isEqualTo(definition);
   }
 }

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtensionTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtensionTest.java
@@ -47,8 +47,7 @@ class ProvisionAdditionalHeadersExtensionTest {
         assertThat(result).matches(StatusResult::succeeded);
 
         await().untilAsserted(() -> {
-            // TODO: change contractId header name to something better
-            verify(dataFlowController).initiateFlow(any(), argThat(it -> it.hasProperty("header:contractId")), any());
+            verify(dataFlowController).initiateFlow(any(), argThat(it -> "aContractId".equals(it.getProperty("header:Edc-Contract-Id"))), any());
         });
     }
 }

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtensionTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtensionTest.java
@@ -75,7 +75,10 @@ class ProvisionAdditionalHeadersExtensionTest {
               verify(dataFlowController)
                   .initiateFlow(
                       any(),
-                      argThat(it -> "aContractId".equals(it.getProperty("header:Edc-Contract-Agreement-Id"))),
+                      argThat(
+                          it ->
+                              "aContractId"
+                                  .equals(it.getProperty("header:Edc-Contract-Agreement-Id"))),
                       any());
             });
   }

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtensionTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtensionTest.java
@@ -1,6 +1,29 @@
+/*
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
-import org.awaitility.Awaitility;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.*;
+
 import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowController;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
@@ -14,40 +37,46 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(EdcExtension.class)
 class ProvisionAdditionalHeadersExtensionTest {
 
-    private final DataFlowController dataFlowController = mock(DataFlowController.class);
+  private final DataFlowController dataFlowController = mock(DataFlowController.class);
 
-    @BeforeEach
-    void setUp() {
-        when(dataFlowController.canHandle(any(), any())).thenReturn(true);
-        when(dataFlowController.initiateFlow(any(), any(), any())).thenReturn(StatusResult.success());
-      }
+  @BeforeEach
+  void setUp() {
+    when(dataFlowController.canHandle(any(), any())).thenReturn(true);
+    when(dataFlowController.initiateFlow(any(), any(), any())).thenReturn(StatusResult.success());
+  }
 
-    @Test
-    void shouldPutContractIdAsHeaderInDataAddress(TransferProcessManager transferProcessManager, AssetIndex assetIndex, DataFlowManager dataFlowManager) {
-        dataFlowManager.register(dataFlowController);
-        var asset = Asset.Builder.newInstance().id("assetId").build();
-        var dataAddress = DataAddress.Builder.newInstance().type("HttpData").build();
-        assetIndex.accept(asset, dataAddress);
+  @Test
+  void shouldPutContractIdAsHeaderInDataAddress(
+      TransferProcessManager transferProcessManager,
+      AssetIndex assetIndex,
+      DataFlowManager dataFlowManager) {
+    dataFlowManager.register(dataFlowController);
+    var asset = Asset.Builder.newInstance().id("assetId").build();
+    var dataAddress = DataAddress.Builder.newInstance().type("HttpData").build();
+    assetIndex.accept(asset, dataAddress);
 
-        var dataRequest = DataRequest.Builder.newInstance()
-                .contractId("aContractId")
-                .assetId("assetId")
-                .destinationType("HttpProxy")
-                .build();
+    var dataRequest =
+        DataRequest.Builder.newInstance()
+            .contractId("aContractId")
+            .assetId("assetId")
+            .destinationType("HttpProxy")
+            .build();
 
-        var result = transferProcessManager.initiateProviderRequest(dataRequest);
+    var result = transferProcessManager.initiateProviderRequest(dataRequest);
 
-        assertThat(result).matches(StatusResult::succeeded);
+    assertThat(result).matches(StatusResult::succeeded);
 
-        await().untilAsserted(() -> {
-            verify(dataFlowController).initiateFlow(any(), argThat(it -> "aContractId".equals(it.getProperty("header:Edc-Contract-Id"))), any());
-        });
-    }
+    await()
+        .untilAsserted(
+            () -> {
+              verify(dataFlowController)
+                  .initiateFlow(
+                      any(),
+                      argThat(it -> "aContractId".equals(it.getProperty("header:Edc-Contract-Id"))),
+                      any());
+            });
+  }
 }

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtensionTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtensionTest.java
@@ -75,7 +75,7 @@ class ProvisionAdditionalHeadersExtensionTest {
               verify(dataFlowController)
                   .initiateFlow(
                       any(),
-                      argThat(it -> "aContractId".equals(it.getProperty("header:Edc-Contract-Id"))),
+                      argThat(it -> "aContractId".equals(it.getProperty("header:Edc-Contract-Agreement-Id"))),
                       any());
             });
   }

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtensionTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtensionTest.java
@@ -1,0 +1,54 @@
+package org.eclipse.tractusx.edc.provision.additionalheaders;
+
+import org.awaitility.Awaitility;
+import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
+import org.eclipse.edc.connector.transfer.spi.flow.DataFlowController;
+import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
+import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.junit.extensions.EdcExtension;
+import org.eclipse.edc.spi.asset.AssetIndex;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(EdcExtension.class)
+class ProvisionAdditionalHeadersExtensionTest {
+
+    private final DataFlowController dataFlowController = mock(DataFlowController.class);
+
+    @BeforeEach
+    void setUp() {
+        when(dataFlowController.canHandle(any(), any())).thenReturn(true);
+        when(dataFlowController.initiateFlow(any(), any(), any())).thenReturn(StatusResult.success());
+      }
+
+    @Test
+    void shouldPutContractIdAsHeaderInDataAddress(TransferProcessManager transferProcessManager, AssetIndex assetIndex, DataFlowManager dataFlowManager) {
+        dataFlowManager.register(dataFlowController);
+        var asset = Asset.Builder.newInstance().id("assetId").build();
+        var dataAddress = DataAddress.Builder.newInstance().type("HttpData").build();
+        assetIndex.accept(asset, dataAddress);
+
+        var dataRequest = DataRequest.Builder.newInstance()
+                .contractId("aContractId")
+                .assetId("assetId")
+                .destinationType("HttpProxy")
+                .build();
+
+        var result = transferProcessManager.initiateProviderRequest(dataRequest);
+
+        assertThat(result).matches(StatusResult::succeeded);
+
+        await().untilAsserted(() -> {
+            // TODO: change contractId header name to something better
+            verify(dataFlowController).initiateFlow(any(), argThat(it -> it.hasProperty("header:contractId")), any());
+        });
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.tractusx.edc.extensions</groupId>
+                <artifactId>provision-additional-headers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.tractusx.edc.extensions</groupId>
                 <artifactId>transferprocess-sftp-client</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
### what
provides a provision extension to enrich the `HttpDataAddress` with an header containing the contract id

### why
to being able to forward that information to the backend data source

### how
registers a resource definition and a provisioner that on the provider side will modify the content data address adding the contract id header: `Edc-Contract-Id`
