### PR TITLE
Replace `provision-oauth2` with `data-plane-http-oauth2`

### DIFF
--- a/docs/samples/README.md
+++ b/docs/samples/README.md
@@ -4,4 +4,4 @@ In this folder are listed some documents that will help you setting up a connect
 
 - [Local setup](./Local%20TXDC%20Setup.md)
 - [Transfer data](./Transfer%20Data.md)
-- [OAuth2 provisioning](./oauth2-provision.md)
+- [Data Plane HTTP OAuth2](./data-plane-http-oauth2.md)

--- a/docs/samples/data-plane-http-oauth2.md
+++ b/docs/samples/data-plane-http-oauth2.md
@@ -1,0 +1,7 @@
+# Data Plane HTTP OAuth2
+
+The Data Plane HTTP OAuth2 extension permits the data-plane to fetch the data requested from a consumer from an HTTP server
+with an OAuth2 authentication layer.
+
+For further documentation, please refer to the extension README:
+https://github.com/eclipse-edc/Connector/tree/main/extensions/data-plane/data-plane-http-oauth2-core

--- a/docs/samples/oauth2-provision.md
+++ b/docs/samples/oauth2-provision.md
@@ -1,7 +1,0 @@
-# OAuth2 Provision
-
-The OAuth2 Provision extension permits the connector to fetch the data requested from a consumer from an HTTP server
-with an OAuth2 authentication layer.
-
-For further documentation and diagram, please refer to the extension README:
-https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core

--- a/edc-controlplane/edc-controlplane-base/pom.xml
+++ b/edc-controlplane/edc-controlplane-base/pom.xml
@@ -146,12 +146,6 @@
             <artifactId>jwt-spi</artifactId>
         </dependency>
 
-        <!-- Provision -->
-        <dependency>
-            <groupId>org.eclipse.edc</groupId>
-            <artifactId>provision-oauth2</artifactId>
-        </dependency>
-
         <!-- Data-Plane -->
         <dependency>
             <groupId>org.eclipse.edc</groupId>

--- a/edc-dataplane/edc-dataplane-base/pom.xml
+++ b/edc-dataplane/edc-dataplane-base/pom.xml
@@ -71,6 +71,10 @@
             <groupId>org.eclipse.edc</groupId>
             <artifactId>data-plane-http</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.edc</groupId>
+            <artifactId>data-plane-http-oauth2</artifactId>
+        </dependency>
 
         <!-- APIs -->
         <dependency>

--- a/edc-tests/src/main/resources/deployment/helm/omejdn/templates/configmap.yaml
+++ b/edc-tests/src/main/resources/deployment/helm/omejdn/templates/configmap.yaml
@@ -40,7 +40,7 @@ data:
 
   clients.yml: |-
       ---
-      - client_id: provision-oauth2
+      - client_id: data-plane-oauth2
         client_secret: supersecret
         name: provision oauth2
         grant_types:

--- a/edc-tests/src/test/resources/org/eclipse/tractusx/edc/tests/features/HttpProxyDataTransfer.feature
+++ b/edc-tests/src/test/resources/org/eclipse/tractusx/edc/tests/features/HttpProxyDataTransfer.feature
@@ -44,8 +44,8 @@ Feature: HttpProxy Data Transfer
 
   Scenario: Connector transfers data via HttpProxy, data on provider side requires oauth2 authentication
     Given 'Plato' has a http proxy assets
-      | id      | description               | baseUrl                          | oauth2 token url     | oauth2 client id | oauth2 client secret | oauth2 scope |
-      | asset-1 | http proxy transfer asset | http://localhost:8081/api/health | http://ids-daps:4567 | provision-oauth2 | supersecret          | openid       |
+      | id      | description               | baseUrl                          | oauth2 token url     | oauth2 client id  | oauth2 client secret | oauth2 scope |
+      | asset-1 | http proxy transfer asset | http://localhost:8081/api/health | http://ids-daps:4567 | data-plane-oauth2 | supersecret          | openid       |
     And 'Plato' has the following policies
       | id       | action |
       | policy-1 | USE    |

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <org.eclipse.dash.license.tool.plugin.version>0.0.1-SNAPSHOT</org.eclipse.dash.license.tool.plugin.version>
 
         <!-- dependency version -->
-        <org.eclipse.edc.version>0.0.1-20230131-SNAPSHOT</org.eclipse.edc.version>
+        <org.eclipse.edc.version>0.0.1-20230209-SNAPSHOT</org.eclipse.edc.version>
         <com.azure.sdk.bom.version>1.2.9</com.azure.sdk.bom.version>
         <org.postgresql.version>42.5.1</org.postgresql.version>
         <org.flywaydb.version>9.14.1</org.flywaydb.version>
@@ -863,6 +863,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.edc</groupId>
+                <artifactId>data-plane-http-oauth2</artifactId>
+                <version>${org.eclipse.edc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.edc</groupId>
                 <artifactId>data-plane-aws-s3</artifactId>
                 <version>${org.eclipse.edc.version}</version>
             </dependency>
@@ -1250,11 +1255,6 @@
             <dependency>
                 <groupId>org.eclipse.edc</groupId>
                 <artifactId>policy-definition-store-sql</artifactId>
-                <version>${org.eclipse.edc.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.edc</groupId>
-                <artifactId>provision-oauth2</artifactId>
                 <version>${org.eclipse.edc.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
### what
replaces `provision-oauth2` with `data-plane-http-oauth2`

### why
apparently there can be only 1 provisioner acting on the provider side modifying the content data address, otherwise they'll clash, as we're introducing the additional headers provisioner in #732 , the behavior of handling oauth2 authorization can be done in the data-plane directly with the `data-plane-http-oauth2` (that in fact will replace the provision extension in its entirety)

NOTE: this needs to be merged before #732, otherwise the business tests there could not pass because the provisioner issue I mentioned.