### PR TITLE
Bump EDC to 20220220

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <org.eclipse.dash.license.tool.plugin.version>0.0.1-SNAPSHOT</org.eclipse.dash.license.tool.plugin.version>
 
         <!-- dependency version -->
-        <org.eclipse.edc.version>0.0.1-20230213-SNAPSHOT</org.eclipse.edc.version>
+        <org.eclipse.edc.version>0.0.1-20230220-SNAPSHOT</org.eclipse.edc.version>
         <com.azure.sdk.bom.version>1.2.9</com.azure.sdk.bom.version>
         <org.postgresql.version>42.5.3</org.postgresql.version>
         <org.flywaydb.version>9.14.1</org.flywaydb.version>


### PR DESCRIPTION
# what

Updates EDC to 20220220.
Compared to the current 20230213 it brings these new commits:

```
bab97cccf fix: catalog pagination (#2494)
f97ff31ab fix: disable flaky ADF test (#2497)
e7945dafa fix: adding missing wrapping transaction blocks in `SqlPolicyDefinitionStore` (#2495)
3d0bd14d6 refactor: move api modules from control-plane to extensions module (#2486)
a89344431 chore: remove unused dependency (#2485)
532f02c30 build(deps): bump com.auth0:java-jwt from 4.2.2 to 4.3.0 (#2484)
```

no braking changes contained