### PR TITLE
chore: update headers and references for tractusx

### DIFF
--- a/charts/edc-controlplane/Chart.yaml
+++ b/charts/edc-controlplane/Chart.yaml
@@ -1,11 +1,35 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: v2
 name: edc-controlplane
 description: >-
   EDC Control-Plane - The Eclipse DataSpaceConnector administration layer with responsibility of resource management and govern contracts and data transfers
-home: https://github.com/catenax-ng/product-edc/charts/edc-controlplane
+home: https://github.com/eclipse-tractusx/tractusx-edc
 type: application
 appVersion: "0.3.0"
 version: 0.3.0
 deprecated: true
 maintainers: []
+sources:
+  - https://github.com/eclipse-tractusx/tractusx-edc

--- a/charts/edc-controlplane/README.md
+++ b/charts/edc-controlplane/README.md
@@ -10,8 +10,8 @@ EDC Control-Plane - The Eclipse DataSpaceConnector administration layer with res
 
 ## TL;DR
 ```shell
-$ helm repo add catenax-ng-product-edc https://catenax-ng.github.io/product-edc
-$ helm install my-release catenax-ng-product-edc/edc-controlplane --version 0.3.0
+$ helm repo add tractusx-edc https://eclipse-tractusx.github.io/charts/dev
+$ helm install my-release tractusx-edc/edc-controlplane --version 0.3.0
 ```
 
 ## Values

--- a/charts/edc-controlplane/README.md.gotmpl
+++ b/charts/edc-controlplane/README.md.gotmpl
@@ -10,8 +10,8 @@
 
 ## TL;DR
 ```shell
-$ helm repo add catenax-ng-product-edc https://catenax-ng.github.io/product-edc
-$ helm install my-release catenax-ng-product-edc/edc-controlplane --version {{ .Version }}
+$ helm repo add tractusx-edc https://eclipse-tractusx.github.io/charts/dev
+$ helm install my-release tractusx-edc/edc-controlplane --version {{ .Version }}
 ```
 
 {{ template "chart.maintainersSection" . }}

--- a/charts/edc-controlplane/templates/configmap-env.yaml
+++ b/charts/edc-controlplane/templates/configmap-env.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/edc-controlplane/templates/configmap.yaml
+++ b/charts/edc-controlplane/templates/configmap.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/edc-controlplane/templates/deployment.yaml
+++ b/charts/edc-controlplane/templates/deployment.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/edc-controlplane/templates/hpa.yaml
+++ b/charts/edc-controlplane/templates/hpa.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 {{- if .Values.autoscaling.enabled }}
 ---
 apiVersion: autoscaling/v2beta1

--- a/charts/edc-controlplane/templates/imagepullsecret.yaml
+++ b/charts/edc-controlplane/templates/imagepullsecret.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 {{- if .Values.imagePullSecret.dockerconfigjson }}
 ---
 apiVersion: v1

--- a/charts/edc-controlplane/templates/ingress.yaml
+++ b/charts/edc-controlplane/templates/ingress.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+  #  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+  #  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+  #
+  #  See the NOTICE file(s) distributed with this work for additional
+  #  information regarding copyright ownership.
+  #
+  #  This program and the accompanying materials are made available under the
+  #  terms of the Apache License, Version 2.0 which is available at
+  #  https://www.apache.org/licenses/LICENSE-2.0
+  #
+  #  Unless required by applicable law or agreed to in writing, software
+  #  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  #  License for the specific language governing permissions and limitations
+  #  under the License.
+  #
+  #  SPDX-License-Identifier: Apache-2.0
+  #
+
 {{- $fullName := include "edc-controlplane.fullname" . }}
 {{- $labels := include "edc-controlplane.labels" . | nindent 4 }}
 {{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}

--- a/charts/edc-controlplane/templates/service.yaml
+++ b/charts/edc-controlplane/templates/service.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: v1
 kind: Service

--- a/charts/edc-controlplane/templates/serviceaccount.yaml
+++ b/charts/edc-controlplane/templates/serviceaccount.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 {{- if .Values.serviceAccount.create -}}
 ---
 apiVersion: v1

--- a/charts/edc-controlplane/values.yaml
+++ b/charts/edc-controlplane/values.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 # Default values for edc-controlplane.
 # This is a YAML-formatted file.

--- a/charts/edc-dataplane/Chart.yaml
+++ b/charts/edc-dataplane/Chart.yaml
@@ -1,11 +1,35 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: v2
 name: edc-dataplane
 description: >-
   EDC Data-Plane - The Eclipse DataSpaceConnector data layer with responsibility of transferring and receiving data streams
-home: https://github.com/catenax-ng/product-edc/charts/edc-dataplane
+home: https://github.com/eclipse-tractusx/tractusx-edc
 type: application
 appVersion: "0.3.0"
 version: 0.3.0
 deprecated: true
 maintainers: []
+sources:
+  - https://github.com/eclipse-tractusx/tractusx-edc

--- a/charts/edc-dataplane/README.md
+++ b/charts/edc-dataplane/README.md
@@ -6,12 +6,12 @@
 
 EDC Data-Plane - The Eclipse DataSpaceConnector data layer with responsibility of transferring and receiving data streams
 
-**Homepage:** <https://github.com/catenax-ng/product-edc/charts/edc-dataplane>
+**Homepage:** <https://github.com/eclipse-tractusx/tractusx-edc>
 
 ## TL;DR
 ```shell
-$ helm repo add catenax-ng-product-edc https://catenax-ng.github.io/product-edc
-$ helm install my-release catenax-ng-product-edc/edc-dataplane --version 0.3.0
+$ helm repo add tractusx-edc https://eclipse-tractusx.github.io/charts/dev
+$ helm install my-release tractusx-edc/edc-dataplane --version 0.3.0
 ```
 
 ## Values

--- a/charts/edc-dataplane/README.md.gotmpl
+++ b/charts/edc-dataplane/README.md.gotmpl
@@ -10,8 +10,8 @@
 
 ## TL;DR
 ```shell
-$ helm repo add catenax-ng-product-edc https://catenax-ng.github.io/product-edc
-$ helm install my-release catenax-ng-product-edc/edc-dataplane --version {{ .Version }}
+$ helm repo add tractusx-edc https://eclipse-tractusx.github.io/charts/dev
+$ helm install my-release tractusx-edc/edc-dataplane --version {{ .Version }}
 ```
 
 {{ template "chart.maintainersSection" . }}

--- a/charts/edc-dataplane/templates/configmap-env.yaml
+++ b/charts/edc-dataplane/templates/configmap-env.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/edc-dataplane/templates/configmap.yaml
+++ b/charts/edc-dataplane/templates/configmap.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/edc-dataplane/templates/deployment.yaml
+++ b/charts/edc-dataplane/templates/deployment.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/edc-dataplane/templates/hpa.yaml
+++ b/charts/edc-dataplane/templates/hpa.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 {{- if .Values.autoscaling.enabled }}
 ---
 apiVersion: autoscaling/v2beta1

--- a/charts/edc-dataplane/templates/imagepullsecret.yaml
+++ b/charts/edc-dataplane/templates/imagepullsecret.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 {{- if .Values.imagePullSecret.dockerconfigjson }}
 ---
 apiVersion: v1

--- a/charts/edc-dataplane/templates/ingress.yaml
+++ b/charts/edc-dataplane/templates/ingress.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 {{- $fullName := include "edc-dataplane.fullname" . }}
 {{- $labels := include "edc-dataplane.labels" . | nindent 4 }}
 {{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}

--- a/charts/edc-dataplane/templates/service.yaml
+++ b/charts/edc-dataplane/templates/service.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: v1
 kind: Service

--- a/charts/edc-dataplane/templates/serviceaccount.yaml
+++ b/charts/edc-dataplane/templates/serviceaccount.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 {{- if .Values.serviceAccount.create -}}
 ---
 apiVersion: v1

--- a/charts/edc-dataplane/values.yaml
+++ b/charts/edc-dataplane/values.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 # Default values for edc-dataplane.
 # This is a YAML-formatted file.

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 #  Copyright (c) 2023 ZF Friedrichshafen AG
-#  Copyright (c) 2022 Mercedes-Benz Tech Innovation GmbH
-#  Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#  Copyright (c) 2022,2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 #  Copyright (c) 2023 ZF Friedrichshafen AG
-#  Copyright (c) 2022 Mercedes-Benz Tech Innovation GmbH
-#  Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#  Copyright (c) 2022,2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 #  Copyright (c) 2023 ZF Friedrichshafen AG
-#  Copyright (c) 2022 Mercedes-Benz Tech Innovation GmbH
-#  Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#  Copyright (c) 2022,2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 #  Copyright (c) 2023 ZF Friedrichshafen AG
-#  Copyright (c) 2022 Mercedes-Benz Tech Innovation GmbH
-#  Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#  Copyright (c) 2022,2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 #  Copyright (c) 2023 ZF Friedrichshafen AG
-#  Copyright (c) 2022 Mercedes-Benz Tech Innovation GmbH
-#  Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#  Copyright (c) 2022,2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.
@@ -18,7 +18,7 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-FROM alpine:3.17.1 as otel
+FROM alpine:3.17.2 as otel
 
 ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.12.1/opentelemetry-javaagent.jar"
 

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 #  Copyright (c) 2023 ZF Friedrichshafen AG
-#  Copyright (c) 2022 Mercedes-Benz Tech Innovation GmbH
-#  Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#  Copyright (c) 2022,2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.


### PR DESCRIPTION
# What
Adds some license headers
Changes some reference from product-edc to tractusx

# Why
This was requested to being able to merge release 0.1.5 to tractusx (https://github.com/eclipse-tractusx/tractusx-edc/pull/86).
There's also an issue that asks to update all the headers to make them match the Eclipse recommendations (https://github.com/eclipse-tractusx/tractusx-edc/issues/88)