### PR TITLE
fix: pin KICS version to v1.5

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
 
       - name: KICS scan
-        uses: checkmarx/kics-github-action@master
+        uses: checkmarx/kics-github-action@v1.5
         with:
           path: "."
           fail_on: high


### PR DESCRIPTION
Pins the version of the KICS action to [1.5](https://github.com/Checkmarx/kics-github-action/releases/tag/v1.5) because it was previously set to `master`, which caused compile errors.

As far as I could determine the problem has to do with OpenSSH and/or webpack. 

Generally, pinned versions are preferable to ensure stable builds.

