### PR TITLE
Add the hint to use an orconstraint instead of a IN operator for the Business Partner Validation Extension

### DIFF
--- a/docs/migration/Version_0.1.x_0.3.x.md
+++ b/docs/migration/Version_0.1.x_0.3.x.md
@@ -11,6 +11,7 @@ details at the [official documentation on swaggerhub](https://app.swaggerhub.com
 - Removed field `assetId` from `ContractOffer`. It was always null though, so there should be nothing to do about it.
 - on `POST /contractdefinitions` a `duration` field can be added to control the duration of the contract.
 - added the `GET /assets/{id}/address` endpoint to being able to retrieve the stored `DataAddress`
+- concerning the Business Partner Validation Extension a so called orconstraint must be used instead of an IN operator. More details in the [related documentation entry](https://github.com/catenax-ng/product-edc/tree/0.3.0/edc-extensions/business-partner-validation)
 
 ## Settings changes
 - Removed default value for setting `edc.transfer.proxy.token.verifier.publickey.alias` so it must be valued accordingly


### PR DESCRIPTION
Data providers (like the simple data exchanger, SDE) are used to add multiple BPNs as a constraint to control the access to certain assets. So far, with version 0.1.6, it was possible to do this by using an IN operator and use an array of BPNs in the `rightExpression#value` of the respective `AtomicConstraint`.

With version 0.3.0 it is necessary to use an `orconstraint` instead of the IN operator. Thus, it is meaningful for the data providers to adjust their data provisioning pipeline accordingly.

The PR adds a bullet point to the changes of the Management API that expresses the above change related to the Business Partner Validation Extension.