### PR TITLE
feat(txdc): add networkPolicy

### DIFF
--- a/charts/tractusx-connector/templates/networkpolicy-controlplane.yaml
+++ b/charts/tractusx-connector/templates/networkpolicy-controlplane.yaml
@@ -1,0 +1,44 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+{{- if eq (.Values.networkPolicy.enabled | toString) "true"  }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "txdc.fullname" . }}-controlplane
+  labels:
+    {{- include "txdc.controlplane.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "txdc.controlplane.selectorLabels" . | nindent 6 }}
+  ingress:
+  {{- if .Values.networkPolicy.controlplane.customFrom }}
+  - from:
+    {{- toYaml .Values.networkPolicy.controlplane.customFrom | nindent 4 }}
+  {{- else }}
+  - from:
+    - podSelector: {}
+  {{- end }}
+    ports:
+    {{- range $key,$value := .Values.controlplane.endpoints }}
+      - port: {{ $value.port }}
+        protocol: TCP
+    {{- end }}
+{{- end }}

--- a/charts/tractusx-connector/templates/networkpolicy-dataplane.yaml
+++ b/charts/tractusx-connector/templates/networkpolicy-dataplane.yaml
@@ -1,0 +1,44 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+{{- if eq (.Values.networkPolicy.enabled | toString) "true"  }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "txdc.fullname" . }}-dataplane
+  labels:
+    {{- include "txdc.dataplane.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "txdc.dataplane.selectorLabels" . | nindent 6 }}
+  ingress:
+  {{- if .Values.networkPolicy.dataplane.customFrom }}
+  - from:
+    {{- toYaml .Values.networkPolicy.dataplane.customFrom | nindent 4 }}
+  {{- else }}
+  - from:
+    - podSelector: {}
+  {{- end }}
+    ports:
+    {{- range $key,$value := .Values.dataplane.endpoints }}
+      - port: {{ $value.port }}
+        protocol: TCP
+    {{- end }}
+{{- end }}

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -497,6 +497,18 @@ daps:
 backendService:
   httpProxyTokenReceiverUrl: ""
 
+networkPolicy:
+  # -- If `true` network policy will be created to restrict access to control- and dataplane
+  enabled: true # TODO: change to false
+  # -- Configuration of the controlplane component
+  controlplane:
+    # -- Specify a custom from rule network policy (cp)
+    customFrom: []
+  # -- Configuration of the dataplane component
+  dataplane:
+    # -- Specify a custom from rule network policy (dp)
+    customFrom: []
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
The `tractusx-connector` Helm chart currently is missing the networkPolicies.
With this PR the default netPols will be added.

Currently the ingress from selector is as follows:

```yaml
  - from:
    - podSelector: {}
```

This will allow every pod from the same namespace to connect to the predefined ports.

If this should be changed please comment this PR - currently with e.g. the value `.Values.networkPolicy.dataplane.customFrom` the from can be customised.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))